### PR TITLE
Add robust db check for checkpoint sync

### DIFF
--- a/beacon-chain/sync/checkpoint/BUILD.bazel
+++ b/beacon-chain/sync/checkpoint/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "api.go",
+        "common.go",
         "file.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/v4/beacon-chain/sync/checkpoint",

--- a/beacon-chain/sync/checkpoint/api.go
+++ b/beacon-chain/sync/checkpoint/api.go
@@ -6,8 +6,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v4/api/client/beacon"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/db"
-	"github.com/prysmaticlabs/prysm/v4/config/params"
-	log "github.com/sirupsen/logrus"
 )
 
 // APIInitializer manages initializing the beacon node using checkpoint sync, retrieving the checkpoint state and root
@@ -29,14 +27,12 @@ func NewAPIInitializer(beaconNodeHost string) (*APIInitializer, error) {
 // Initialize downloads origin state and block for checkpoint sync and initializes database records to
 // prepare the node to begin syncing from that point.
 func (dl *APIInitializer) Initialize(ctx context.Context, d db.Database) error {
-	origin, err := d.OriginCheckpointBlockRoot(ctx)
-	if err == nil && origin != params.BeaconConfig().ZeroHash {
-		log.Warnf("origin checkpoint root %#x found in db, ignoring checkpoint sync flags", origin)
+	exists, err := isCheckpointStatePresent(ctx, d)
+	if err != nil {
+		return err
+	}
+	if exists {
 		return nil
-	} else {
-		if !errors.Is(err, db.ErrNotFound) {
-			return errors.Wrap(err, "error while checking database for origin root")
-		}
 	}
 	od, err := beacon.DownloadFinalizedData(ctx, dl.c)
 	if err != nil {

--- a/beacon-chain/sync/checkpoint/common.go
+++ b/beacon-chain/sync/checkpoint/common.go
@@ -17,7 +17,10 @@ type Initializer interface {
 // isCheckpointStatePresent checks if the checkpoint and corresponding state exist in the database.
 func isCheckpointStatePresent(ctx context.Context, d db.Database) (bool, error) {
 	origin, err := d.OriginCheckpointBlockRoot(ctx)
-	if err != nil && !errors.Is(err, db.ErrNotFound) {
+	if err != nil  {
+		if errors.Is(err, db.ErrNotFound){
+			return false, nil
+		}
 		return false, errors.Wrap(err, "error while checking database for origin root")
 	}
 	// Check corresponding state

--- a/beacon-chain/sync/checkpoint/common.go
+++ b/beacon-chain/sync/checkpoint/common.go
@@ -1,0 +1,28 @@
+package checkpoint
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v4/beacon-chain/db"
+)
+
+// Initializer describes a type that is able to obtain the checkpoint sync data (BeaconState and SignedBeaconBlock)
+// in some way and perform database setup to prepare the beacon node for syncing from the given checkpoint.
+// See FileInitializer and APIInitializer.
+type Initializer interface {
+	Initialize(ctx context.Context, d db.Database) error
+}
+
+// isCheckpointStatePresent checks if the checkpoint and corresponding state exist in the database.
+func isCheckpointStatePresent(ctx context.Context, d db.Database) (bool, error) {
+	origin, err := d.OriginCheckpointBlockRoot(ctx)
+	if err != nil && !errors.Is(err, db.ErrNotFound) {
+		return false, errors.Wrap(err, "error while checking database for origin root")
+	}
+	// Check corresponding state
+	if d.HasState(ctx, origin) {
+		return true, nil
+	}
+	return false, nil
+}

--- a/beacon-chain/sync/checkpoint/common.go
+++ b/beacon-chain/sync/checkpoint/common.go
@@ -17,8 +17,8 @@ type Initializer interface {
 // isCheckpointStatePresent checks if the checkpoint and corresponding state exist in the database.
 func isCheckpointStatePresent(ctx context.Context, d db.Database) (bool, error) {
 	origin, err := d.OriginCheckpointBlockRoot(ctx)
-	if err != nil  {
-		if errors.Is(err, db.ErrNotFound){
+	if err != nil {
+		if errors.Is(err, db.ErrNotFound) {
 			return false, nil
 		}
 		return false, errors.Wrap(err, "error while checking database for origin root")

--- a/beacon-chain/sync/checkpoint/file.go
+++ b/beacon-chain/sync/checkpoint/file.go
@@ -7,17 +7,8 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/db"
-	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/io/file"
-	log "github.com/sirupsen/logrus"
 )
-
-// Initializer describes a type that is able to obtain the checkpoint sync data (BeaconState and SignedBeaconBlock)
-// in some way and perform database setup to prepare the beacon node for syncing from the given checkpoint.
-// See FileInitializer and APIInitializer.
-type Initializer interface {
-	Initialize(ctx context.Context, d db.Database) error
-}
 
 // NewFileInitializer validates the given path information and creates an Initializer which will
 // use the provided state and block files to prepare the node for checkpoint sync.
@@ -43,14 +34,12 @@ type FileInitializer struct {
 // Initialize is called in the BeaconNode db startup code if an Initializer is present.
 // Initialize does what is needed to prepare the beacon node database for syncing from the weak subjectivity checkpoint.
 func (fi *FileInitializer) Initialize(ctx context.Context, d db.Database) error {
-	origin, err := d.OriginCheckpointBlockRoot(ctx)
-	if err == nil && origin != params.BeaconConfig().ZeroHash {
-		log.Warnf("origin checkpoint root %#x found in db, ignoring checkpoint sync flags", origin)
+	exists, err := isCheckpointStatePresent(ctx, d)
+	if err != nil {
+		return err
+	}
+	if exists {
 		return nil
-	} else {
-		if !errors.Is(err, db.ErrNotFound) {
-			return errors.Wrap(err, "error while checking database for origin root")
-		}
 	}
 	serBlock, err := file.ReadFileAsBytes(fi.blockPath)
 	if err != nil {


### PR DESCRIPTION
When checkpoint sync is enabled, beacon node checks db whether the checkpoint origin block root exists in db. If it exists, it skips checkpoint sync progress(e.g. download finalized data from remote url).

This work adds a robust check for checkpoint sync. By checking if a checkpoint state exists in db, this will remove the chance of failing in init process like:

```plain
Fri Aug 23 2024 15:39:29 GMT+0900 (Korean Standard Time) could not get ancestor state: slot 69983 not in db due to checkpoint sync: cannot retrieve data for slot
```