### PR TITLE
Update p2p metaData file when it is changed

### DIFF
--- a/beacon-chain/p2p/BUILD.bazel
+++ b/beacon-chain/p2p/BUILD.bazel
@@ -157,6 +157,7 @@ go_test(
         "//crypto/ecdsa:go_default_library",
         "//crypto/hash:go_default_library",
         "//encoding/bytesutil:go_default_library",
+        "//io/file:go_default_library",
         "//network:go_default_library",
         "//network/forks:go_default_library",
         "//proto/eth/v1:go_default_library",

--- a/beacon-chain/p2p/service.go
+++ b/beacon-chain/p2p/service.go
@@ -288,6 +288,18 @@ func (s *Service) Stop() error {
 	if s.dv5Listener != nil {
 		s.dv5Listener.Close()
 	}
+
+	// Save metadata to file if static peer id is enabled.
+	if s.cfg.StaticPeerID {
+		md := s.Metadata()
+		mdPath, exist := resolveMetaDataPath(s.cfg)
+		if exist {
+			err := saveMetaDataToFile(mdPath, md)
+			if err != nil {
+				log.WithError(err).Error("Could not save metadata to file")
+			}
+		}
+	}
 	return nil
 }
 

--- a/beacon-chain/p2p/utils.go
+++ b/beacon-chain/p2p/utils.go
@@ -15,7 +15,8 @@ import (
 	"github.com/ethereum/go-ethereum/p2p/enr"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/go-bitfield"
+	ssz "github.com/prysmaticlabs/fastssz"
+	bitfield "github.com/prysmaticlabs/go-bitfield"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/wrapper"
 	ecdsaprysm "github.com/prysmaticlabs/prysm/v5/crypto/ecdsa"
 	"github.com/prysmaticlabs/prysm/v5/io/file"
@@ -116,43 +117,130 @@ func privKeyFromFile(path string) (*ecdsa.PrivateKey, error) {
 
 // Retrieves node p2p metadata from a set of configuration values
 // from the p2p service.
-// TODO: Figure out how to do a v1/v2 check.
+// When using static peer id, metaDataFromConfig returns default V1 metadata.
 func metaDataFromConfig(cfg *Config) (metadata.Metadata, error) {
-	defaultKeyPath := path.Join(cfg.DataDir, metaDataPath)
-	metaDataPath := cfg.MetaDataDir
+	// Load V1 metadata by default, since V1 metadata can be covered to V0.
+	defaultMd := &pb.MetaDataV1{
+		SeqNumber: 0,
+		Attnets:   bitfield.NewBitvector64(),
+		Syncnets:  bitfield.NewBitvector4(),
+	}
+	wrappedDefaultMd := wrapper.WrappedMetadataV1(defaultMd)
 
-	_, err := os.Stat(defaultKeyPath)
-	defaultMetadataExist := !os.IsNotExist(err)
-	if err != nil && defaultMetadataExist {
+	// If --p2p-static-id is false, return default metadata for initialization
+	if !cfg.StaticPeerID {
+		return wrappedDefaultMd, nil
+	}
+
+	mdPath, exist := resolveMetaDataPath(cfg)
+	if exist {
+		md, err := metaDataFromFile(mdPath)
+		if err != nil {
+			if errors.Is(err, ssz.ErrSize) {
+				// In case previous metadata file is encoded by proto,
+				// we need to migrate it into ssz encoded version.
+				return migrateFromProtoToSsz(mdPath)
+			}
+			return nil, err
+		}
+		return md, err
+	}
+	if err := saveMetaDataToFile(mdPath, wrappedDefaultMd); err != nil {
 		return nil, err
 	}
-	if metaDataPath == "" && !defaultMetadataExist {
-		metaData := &pb.MetaDataV0{
-			SeqNumber: 0,
-			Attnets:   bitfield.NewBitvector64(),
-		}
-		dst, err := proto.Marshal(metaData)
-		if err != nil {
-			return nil, err
-		}
-		if err := file.WriteFile(defaultKeyPath, dst); err != nil {
-			return nil, err
-		}
-		return wrapper.WrappedMetadataV0(metaData), nil
+
+	return wrappedDefaultMd, nil
+}
+
+// resolveMetaDataPath returns path and the existence of that path.
+// Issue while opening a file(e.g. permission issues) will be handled at metaDataFromFile.
+func resolveMetaDataPath(cfg *Config) (string, bool) {
+	var mdPath string
+
+	// Prioritize if --p2p-metadata is provided.
+	if cfg.MetaDataDir != "" {
+		mdPath = cfg.MetaDataDir
+	} else {
+		mdPath = path.Join(cfg.DataDir, metaDataPath)
 	}
-	if defaultMetadataExist && metaDataPath == "" {
-		metaDataPath = defaultKeyPath
+
+	// Return path and existence of the file.
+	_, err := os.Stat(mdPath)
+	if !os.IsNotExist(err) {
+		return mdPath, true
 	}
-	src, err := os.ReadFile(metaDataPath) // #nosec G304
+	return mdPath, false
+}
+
+// metaDataFromFile retrieves unmarshalled p2p metadata from file.
+func metaDataFromFile(path string) (metadata.Metadata, error) {
+	src, err := os.ReadFile(path) // #nosec G304
 	if err != nil {
 		log.WithError(err).Error("Error reading metadata from file")
 		return nil, err
 	}
-	metaData := &pb.MetaDataV0{}
-	if err := proto.Unmarshal(src, metaData); err != nil {
+
+	// Load V1 version (after altair) regardless of current fork by default.
+	md := &pb.MetaDataV1{}
+	err = md.UnmarshalSSZ(src)
+	if err != nil {
+		// If unmarshal failed, try to unmarshal for V0
+		log.WithError(err).Info("Error unmarshalling V1 metadata from file, try to unmarshal for V0.")
+		md0 := &pb.MetaDataV0{}
+		md0Err := md0.UnmarshalSSZ(src)
+		if md0Err != nil {
+			log.WithError(md0Err).Error("Error unmarshalling V0 metadata from file")
+			return nil, md0Err
+		}
+		return wrapper.WrappedMetadataV0(md0), nil
+	}
+	return wrapper.WrappedMetadataV1(md), nil
+}
+
+// saveMetaDataToFile writes marshalled metadata to given path.
+func saveMetaDataToFile(path string, metadata metadata.Metadata) error {
+	enc, err := metadata.MarshalSSZ()
+	if err != nil {
+		log.WithError(err).Error("Error marshalling metadata to SSZ")
+		return err
+	}
+
+	if err := file.WriteFile(path, enc); err != nil {
+		log.WithError(err).Error("Failed to write to disk")
+		return err
+	}
+	return nil
+}
+
+// migrateFromProtoToSsz tries to unmarshal by proto, and migrates to ssz encoded file
+// if unmarshalling is successful.
+func migrateFromProtoToSsz(path string) (metadata.Metadata, error) {
+	src, err := os.ReadFile(path) // #nosec G304
+	if err != nil {
+		log.WithError(err).Error("Error reading metadata from file")
 		return nil, err
 	}
-	return wrapper.WrappedMetadataV0(metaData), nil
+
+	md := &pb.MetaDataV0{}
+	if err := proto.Unmarshal(src, md); err != nil {
+		return nil, err
+	}
+
+	wmd := wrapper.WrappedMetadataV0(md)
+	// increment sequence number
+	seqNum := wmd.SequenceNumber() + 1
+	newMd := &pb.MetaDataV1{
+		SeqNumber: seqNum,
+		Attnets:   wmd.AttnetsBitfield().Bytes(),
+		Syncnets:  bitfield.NewBitvector4(),
+	}
+	wrappedNewMd := wrapper.WrappedMetadataV1(newMd)
+
+	saveErr := saveMetaDataToFile(path, wrappedNewMd)
+	if saveErr != nil {
+		return nil, saveErr
+	}
+	return wrapper.WrappedMetadataV1(newMd), nil
 }
 
 // Attempt to dial an address to verify its connectivity

--- a/beacon-chain/p2p/utils_test.go
+++ b/beacon-chain/p2p/utils_test.go
@@ -2,11 +2,13 @@ package p2p
 
 import (
 	"fmt"
+	"math/rand"
 	"path/filepath"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
+	"github.com/prysmaticlabs/go-bitfield"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/wrapper"
 	"github.com/prysmaticlabs/prysm/v5/io/file"
@@ -14,6 +16,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/testing/assert"
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
 	logTest "github.com/sirupsen/logrus/hooks/test"
+	"google.golang.org/protobuf/proto"
 )
 
 // Test `verifyConnectivity` function by trying to connect to google.com (successfully)

--- a/beacon-chain/p2p/utils_test.go
+++ b/beacon-chain/p2p/utils_test.go
@@ -2,11 +2,15 @@ package p2p
 
 import (
 	"fmt"
+	"path/filepath"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/p2p/enode"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
+	"github.com/prysmaticlabs/prysm/v5/consensus-types/wrapper"
+	"github.com/prysmaticlabs/prysm/v5/io/file"
+	pb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 	"github.com/prysmaticlabs/prysm/v5/testing/assert"
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
 	logTest "github.com/sirupsen/logrus/hooks/test"
@@ -63,4 +67,76 @@ func TestSerializeENR(t *testing.T) {
 		require.NotNil(t, err)
 		assert.ErrorContains(t, "could not serialize nil record", err)
 	})
+}
+
+func TestMetaDataFromFile(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, metaDataPath)
+
+	// Generate metadata V1
+	seqNum := rand.Uint64()
+	md := &pb.MetaDataV1{
+		SeqNumber: seqNum,
+		Attnets:   bitfield.NewBitvector64(),
+		Syncnets:  bitfield.NewBitvector4(),
+	}
+	metaData := wrapper.WrappedMetadataV1(md)
+
+	// Save to file
+	err := saveMetaDataToFile(path, metaData.Copy())
+	require.NoError(t, err)
+
+	// Load file, and compare
+	mdFromFile, err := metaDataFromFile(path)
+	require.NoError(t, err)
+	require.DeepEqual(t, metaData.Copy(), mdFromFile.Copy())
+}
+
+func TestMetaDataFromFile_V0(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, metaDataPath)
+
+	// Generate metadata V0
+	seqNum := rand.Uint64()
+	md := &pb.MetaDataV0{
+		SeqNumber: seqNum,
+		Attnets:   bitfield.NewBitvector64(),
+	}
+	metaData := wrapper.WrappedMetadataV0(md)
+
+	// Save to file
+	err := saveMetaDataToFile(path, metaData.Copy())
+	require.NoError(t, err)
+
+	// Load file, and compare
+	mdFromFile, err := metaDataFromFile(path)
+	require.NoError(t, err)
+	require.DeepEqual(t, metaData.Copy(), mdFromFile.Copy())
+}
+
+func TestMetaDataMigrationFromProtoToSsz(t *testing.T) {
+	params.SetupTestConfigCleanup(t)
+	tempDir := t.TempDir()
+	path := filepath.Join(tempDir, metaDataPath)
+
+	// Generate metadata V0 and save with proto-encoded
+	seqNum := rand.Uint64()
+	md := &pb.MetaDataV0{
+		SeqNumber: seqNum,
+		Attnets:   bitfield.NewBitvector64(),
+	}
+	wmd := wrapper.WrappedMetadataV0(md)
+	dst, err := proto.Marshal(md)
+	require.NoError(t, err)
+
+	err = file.WriteFile(path, dst)
+	require.NoError(t, err)
+
+	migratedMd, err := migrateFromProtoToSsz(path)
+	require.NoError(t, err)
+
+	// Check if sequence number is incremented
+	require.Equal(t, wmd.SequenceNumber()+1, migratedMd.SequenceNumber())
 }

--- a/proto/prysm/v1alpha1/p2p_messages.proto
+++ b/proto/prysm/v1alpha1/p2p_messages.proto
@@ -51,6 +51,7 @@ message MetaDataV0 {
  (
  seq_number: uint64
  attnets: Bitvector[ATTESTATION_SUBNET_COUNT]
+ syncnets: Bitvector[SYNC_COMMITTEE_SUBNET_COUNT]
  )
 */
 message MetaDataV1 {


### PR DESCRIPTION
This PR addresses prysm issue #13586, where the beacon-chain does not update the `metaData` file as expected. The issue arises because there is currently no code to write to the `metaData` file after initialization. As a result, the sequence number stored on disk always remains **zero**. This behavior is acceptable when the `--p2p-static-id` flag is not provided. However, it causes significant issues in the P2P processes when a user intends to maintain the same peer ID across sessions. (especially when ping to peers, but those peers found that the sequence number of sender is lower than they manage in their own tables.)

**Other notes for review**

- There is a migration code(`migrateFromProtoToSsz`) in case user has `metaData` file already.
- A point of discussion: Should we handle potential errors when the P2P service encounters issues while writing to files? Currently, these errors are ignored. Feedback on this approach would be appreciated.