### PR TITLE
Fix `/v2/validator/health/status`: use snake case for response

### DIFF
--- a/validator/rpc/handlers_health.go
+++ b/validator/rpc/handlers_health.go
@@ -196,10 +196,10 @@ func (s *Server) GetStatus(w http.ResponseWriter, r *http.Request) {
 	}
 
 	httputil.WriteJson(w, struct {
-		IsConnectedWithBeaconNode bool `json:"isConnectedWithBeaconNode"`
-		IsBeaconNodeSyncing       bool `json:"isBeaconNodeSyncing"`
-		IsWalletInitialized       bool `json:"isWalletInitialized"`
-		CanInitializeWallet       bool `json:"canInitializeWallet"`
+		IsConnectedWithBeaconNode bool `json:"is_connected_with_beacon_node"`
+		IsBeaconNodeSyncing       bool `json:"is_beacon_node_syncing"`
+		IsWalletInitialized       bool `json:"is_wallet_initialized"`
+		CanInitializeWallet       bool `json:"can_initialize_wallet"`
 	}{
 		IsConnectedWithBeaconNode: isConnectionWithBeaconNode,
 		IsBeaconNodeSyncing:       isBeaconNodeSyncing,

--- a/validator/rpc/handlers_health_test.go
+++ b/validator/rpc/handlers_health_test.go
@@ -217,5 +217,5 @@ func TestServer_GetStatus(t *testing.T) {
 	body, err := io.ReadAll(resp.Body)
 	require.NoError(t, err)
 	require.NotNil(t, body)
-	require.StringContains(t, `{"isConnectedWithBeaconNode":false,"isBeaconNodeSyncing":false,"isWalletInitialized":false,"canInitializeWallet":false}`, string(body))
+	require.StringContains(t, `{"is_connected_with_beacon_node":false,"is_beacon_node_syncing":false,"is_wallet_initialized":false,"can_initialize_wallet":false}`, string(body))
 }


### PR DESCRIPTION
`/v2/validator/health/status` must return as `snake_case` for OverScape.