### PR TITLE
CI/CD issues: Resolve docker build issue

### DIFF
--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -125,12 +125,18 @@ jobs:
         id: changelog
         run: |
           git fetch --tags
-          prev_tag=$(git tag --sort=-version:refname | grep -e "^v[0-9.]*$" | head -n 1)
+
+          # Extract version (e.g., v1.4.9 -> 1.4 & 9)
+          major_minor_version=$(echo "${{ needs.extract-version.outputs.version_name }}" | sed -E 's/^v([0-9]+\.[0-9]+)\.[0-9]+/\1/')
+          current_patch_version=$(echo "${{ needs.extract-version.outputs.version_name }}" | sed -E 's/^v[0-9]+\.[0-9]+\.([0-9]+)/\1/')
+
+          prev_tag=$(git tag --sort=-version:refname | grep -E "^v${major_minor_version}\.[0-9]+_${{ needs.extract-version.outputs.tag_name }}$" | grep -v "${current_patch_version}_${{ needs.extract-version.outputs.tag_name }}" | head -n 1)
+
           echo "previous release: $prev_tag"
           if [ "$prev_tag" ]; then
-            changelog=$(git log --oneline --no-decorate $prev_tag..HEAD)
+            changelog=$(git log --oneline --no-decorate $prev_tag..HEAD --reverse)
           else
-            changelog=$(git log --oneline --no-decorate)
+            changelog="fix me"
           fi
           echo "changelog<<EOF" >> $GITHUB_OUTPUT
           echo " - ${changelog//$'\n'/$'\n' - }" >> $GITHUB_OUTPUT

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -101,9 +101,9 @@ http_archive(
 
 http_archive(
     name = "aspect_bazel_lib",
-    sha256 = "f5ea76682b209cc0bd90d0f5a3b26d2f7a6a2885f0c5f615e72913f4805dbb0d",
-    strip_prefix = "bazel-lib-2.5.0",
-    url = "https://github.com/aspect-build/bazel-lib/releases/download/v2.5.0/bazel-lib-v2.5.0.tar.gz",
+    sha256 = "a272d79bb0ac6b6965aa199b1f84333413452e87f043b53eca7f347a23a478e8",
+    strip_prefix = "bazel-lib-2.9.3",
+    url = "https://github.com/bazel-contrib/bazel-lib/releases/download/v2.9.3/bazel-lib-v2.9.3.tar.gz",
 )
 
 load("@aspect_bazel_lib//lib:repositories.bzl", "aspect_bazel_lib_dependencies", "aspect_bazel_lib_register_toolchains")

--- a/tools/image_deps.bzl
+++ b/tools/image_deps.bzl
@@ -39,7 +39,7 @@ def prysm_image_deps():
         package_name = "libtinfo6", # Required by: bash
         sha256 = "58027c991756930a2abb2f87a829393d3fdbfb76f4eca9795ef38ea2b0510e27",
         urls = [
-            "https://snapshot.debian.org/archive/debian/20231214T085654Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u1_arm64.deb",
+            "https://snapshot.debian.org/archive/debian/20231214T085654Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u2_arm64.deb",
             "https://prysmaticlabs.com/uploads/libtinfo6_6.2+20201114-2+deb11u2_arm64.deb",
         ],
     )


### PR DESCRIPTION
Fix CI/CD issues.

- 338b57c6ce0a2afe1d6a902e5677f008f34334c6: `libtinfo6` had wrong snapshot url, causing `WARNING: Download from https://snapshot.debian.org/archive/debian/20231214T085654Z/pool/main/n/ncurses/libtinfo6_6.2+20201114-2+deb11u1_arm64.deb failed: class java.io.FileNotFoundException GET returned 404 NOT FOUND`
- 27e66f851e76462d3cd4518bffc2e69544762eb1: `libarchive-tools` was updated few days ago, yet our bazel-lib version doens't know. This fixes `WARNING: Download from http://security.ubuntu.com/ubuntu/pool/universe/liba/libarchive/libarchive-tools_3.4.0-2ubuntu1.2_amd64.deb failed: class java.io.FileNotFoundException GET returned 404 Not Found` issue.
- 1559211a4898980789bdac280ac0f3209e7ad4a0: Change log will reflect the diff between previous tag and current HEAD more accurately