### PR TITLE
Replace gorilla/mux to net/http in go for `over` handlers

### DIFF
--- a/beacon-chain/rpc/over/BUILD.bazel
+++ b/beacon-chain/rpc/over/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//network/httputil:go_default_library",
         "//time/slots:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
-        "@com_github_gorilla_mux//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@io_opencensus_go//trace:go_default_library",
     ],
@@ -48,6 +47,5 @@ go_test(
         "//testing/util:go_default_library",
         "//time/slots:go_default_library",
         "@com_github_ethereum_go_ethereum//common/hexutil:go_default_library",
-        "@com_github_gorilla_mux//:go_default_library",
     ],
 )

--- a/beacon-chain/rpc/over/handlers.go
+++ b/beacon-chain/rpc/over/handlers.go
@@ -6,7 +6,6 @@ import (
 	"strconv"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"github.com/prysmaticlabs/prysm/v5/api/server/structs"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
@@ -40,7 +39,7 @@ func (s *Server) EstimatedActivation(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	rawId := mux.Vars(r)["validator_id"]
+	rawId := r.PathValue("validator_id")
 	valIndex, err := decodeValidatorId(st, rawId)
 	if err != nil {
 		httputil.WriteError(w, handleWrapError(err, "could not decode validator id from raw id", http.StatusBadRequest))
@@ -137,7 +136,7 @@ func (s *Server) GetEpochReward(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	var requestedEpoch primitives.Epoch
-	epochId := mux.Vars(r)["epoch"]
+	epochId := r.PathValue("epoch")
 	curEpoch := slots.ToEpoch(s.GenesisTimeFetcher.CurrentSlot())
 
 	if epochId == "latest" {
@@ -181,7 +180,7 @@ func (s *Server) GetReserves(w http.ResponseWriter, r *http.Request) {
 	defer span.End()
 
 	// Retrieve beacon state
-	stateId := mux.Vars(r)["state_id"]
+	stateId := r.PathValue("state_id")
 	if stateId == "" {
 		httputil.HandleError(w, "state_id is required in URL params", http.StatusBadRequest)
 		return

--- a/beacon-chain/rpc/over/handlers_test.go
+++ b/beacon-chain/rpc/over/handlers_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/gorilla/mux"
 	"github.com/prysmaticlabs/prysm/v5/api/server/structs"
 	chainMock "github.com/prysmaticlabs/prysm/v5/beacon-chain/blockchain/testing"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
@@ -138,7 +137,7 @@ func TestEstimatedActivation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			request := httptest.NewRequest(http.MethodPost, "http://example.com//chronos/validator/estimated_activation/{validator_id}", nil)
-			request = mux.SetURLVars(request, map[string]string{"validator_id": tt.input})
+			request.SetPathValue("validator_id", tt.input)
 			writer := httptest.NewRecorder()
 			writer.Body = &bytes.Buffer{}
 
@@ -170,7 +169,7 @@ func TestEstimatedActivation_NoPendingValidators(t *testing.T) {
 
 	t.Run("empty request", func(t *testing.T) {
 		request := httptest.NewRequest(http.MethodPost, "http://example.com//chronos/validator/estimated_activation/{validator_id}", nil)
-		request = mux.SetURLVars(request, map[string]string{"validator_id": ""})
+		request.SetPathValue("validator_id", "")
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 
@@ -227,7 +226,7 @@ func TestGetEpochReward(t *testing.T) {
 
 		request := httptest.NewRequest(
 			"GET", "/chronos/states/epoch_reward/{epoch}", nil)
-		request = mux.SetURLVars(request, map[string]string{"epoch": "100"})
+		request.SetPathValue("epoch", "100")
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 
@@ -254,7 +253,7 @@ func TestGetEpochReward(t *testing.T) {
 
 		request := httptest.NewRequest(
 			"GET", "/chronos/states/epoch_reward/{epoch}", nil)
-		request = mux.SetURLVars(request, map[string]string{"epoch": "latest"})
+		request.SetPathValue("epoch", "latest")
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 
@@ -284,7 +283,7 @@ func TestGetEpochReward(t *testing.T) {
 
 		request := httptest.NewRequest(
 			"GET", "/chronos/states/epoch_reward/{epoch}", nil)
-		request = mux.SetURLVars(request, map[string]string{"epoch": "100"})
+		request.SetPathValue("epoch", "100")
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 
@@ -323,7 +322,7 @@ func TestGetReserves(t *testing.T) {
 		}
 		request := httptest.NewRequest(
 			"GET", "/over/v1/beacon/states/{state_id}/reserves", nil)
-		request = mux.SetURLVars(request, map[string]string{"state_id": "head"})
+		request.SetPathValue("state_id", "head")
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 
@@ -348,7 +347,6 @@ func TestGetReserves(t *testing.T) {
 		}
 		request := httptest.NewRequest(
 			"GET", "/over/v1/beacon/states/{state_id}/reserves", nil)
-		request = mux.SetURLVars(request, map[string]string{})
 		writer := httptest.NewRecorder()
 		writer.Body = &bytes.Buffer{}
 

--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,6 @@ require (
 	github.com/google/go-cmp v0.6.0
 	github.com/google/gofuzz v1.2.0
 	github.com/google/uuid v1.6.0
-	github.com/gorilla/mux v1.8.0
 	github.com/gostaticanalysis/comment v1.4.2
 	github.com/grpc-ecosystem/go-grpc-middleware v1.2.2
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -432,7 +432,6 @@ github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORR
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.8.0 h1:i40aqfkR1h2SlN9hojwV5ZA91wcXFOvkdNIeFDP5koI=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=


### PR DESCRIPTION
At [Prysm 5.1.1](https://github.com/prysmaticlabs/prysm/releases/tag/v5.1.1), gorilla mux was replaced to net/http in go 1.22. This change wasn't applied to the handlers in `over` package, so applied.