### PR TITLE
Adjust reboot threshold to use `min-sync-peers`

### DIFF
--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -18,6 +18,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/cache"
 	"github.com/prysmaticlabs/prysm/v5/cmd/beacon-chain/flags"
 	"github.com/prysmaticlabs/prysm/v5/config/features"
+	"github.com/prysmaticlabs/prysm/v5/config/params"
 	ecdsaprysm "github.com/prysmaticlabs/prysm/v5/crypto/ecdsa"
 	"github.com/prysmaticlabs/prysm/v5/time/slots"
 )

--- a/beacon-chain/p2p/discovery.go
+++ b/beacon-chain/p2p/discovery.go
@@ -181,7 +181,7 @@ func (s *Service) listenForNewNodes() {
 			if !features.Get().EnableDiscoveryReboot {
 				continue
 			}
-			if !s.isBelowOutboundPeerThreshold() {
+			if !s.isBelowMinimumSyncPeers() {
 				// Reset counter if we are beyond the threshold
 				thresholdCount = 0
 				continue
@@ -189,7 +189,7 @@ func (s *Service) listenForNewNodes() {
 			thresholdCount++
 			// Reboot listener if connectivity drops
 			if thresholdCount > 5 {
-				log.WithField("outboundConnectionCount", len(s.peers.OutboundConnected())).Warn("Rebooting discovery listener, reached threshold.")
+				log.WithField("connectionCount", len(s.peers.Connected())).Warn("Rebooting discovery listener, reached threshold.")
 				if err := s.dv5Listener.RebootListener(); err != nil {
 					log.WithError(err).Error("Could not reboot listener")
 					continue
@@ -496,6 +496,18 @@ func (s *Service) isBelowOutboundPeerThreshold() bool {
 	outBoundThreshold := outboundFloor / 2
 	outBoundCount := len(s.Peers().OutboundConnected())
 	return outBoundCount < outBoundThreshold
+}
+
+// isBelowMinimumSyncPeers checks if the number of peers that we are connected to
+// is below the minimum number of peers required for syncing.
+// required is from waitForMinimumPeers.
+func (s *Service) isBelowMinimumSyncPeers() bool {
+	required := params.BeaconConfig().MaxPeersToSync
+	if flags.Get().MinimumSyncPeers < required {
+		required = flags.Get().MinimumSyncPeers
+	}
+	connectedPeers := len(s.Peers().Connected())
+	return connectedPeers < required
 }
 
 func (s *Service) wantedPeerDials() int {


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

This work adjusts the condition for rebooting p2p listener. In every minute, it checks specific condition so the threshold count can be incremented or reset. If the threshold count is larger than `5`, the service reboots its discv5 listener. The condition is: 

- As-is(`isBelowOutboundPeerThreshold`): outbound connected peer count vs. outbound threshold.
  - `outboundThreshold` is decided by `inboundRatio` and `MaxPeers`.
  - e.g. `MaxPeers` = 70, `outboundFloor` = `MaxPeers` - `MaxPeers` * `inboundRatio`(= 0.8) = 14, `outBoundThreshold` = `outboundFloor` / 2 = 7
- To-be(`isBelowMinimumSyncPeers`): connected peer count vs. minimum sync peer count (default to `3`)

The condition has became much stricter, so adding `enable-discovery-reboot` flag on OverScape as a default would be helpful for users who have troubles in p2p.


### Hacks
Use those flags to test this feature:
```
--min-sync-peers 10 --enable-discovery-reboot 
```

