### PR TITLE
Add Bazel remote cache server for CI/CD

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -60,9 +60,4 @@ build --host_cxxopt=-std=c++20
 build:remote-cache --remote_cache=https://storage.googleapis.com/chronos-bazel-cache
 build:remote-cache --remote_download_minimal
 build:remote-cache --remote_build_event_upload=minimal
-build:remote-cache --remote_local_fallback
-build:remote-cache --experimental_remote_cache_async
-build:remote-cache --experimental_remote_merkle_tree_cache
-build:remote-cache --experimental_action_cache_store_output_metadata
-build:remote-cache --experimental_remote_cache_compression
 build:remote-cache --google_default_credentials

--- a/.bazelrc
+++ b/.bazelrc
@@ -55,3 +55,14 @@ build --define gotags=bazel
 # Abseil requires c++14 or greater.
 build --cxxopt=-std=c++20
 build --host_cxxopt=-std=c++20
+
+# remote-cache properties
+build:remote-cache --remote_cache=https://storage.googleapis.com/chronos-bazel-cache
+build:remote-cache --remote_download_minimal
+build:remote-cache --remote_build_event_upload=minimal
+build:remote-cache --remote_local_fallback
+build:remote-cache --experimental_remote_cache_async
+build:remote-cache --experimental_remote_merkle_tree_cache
+build:remote-cache --experimental_action_cache_store_output_metadata
+build:remote-cache --experimental_remote_cache_compression
+build:remote-cache --google_default_credentials

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,5 @@
 bazel-*
 .git
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json

--- a/.github/workflows/_build-bazel.yml
+++ b/.github/workflows/_build-bazel.yml
@@ -12,14 +12,30 @@ on:
       version_name:
         required: true
         type: string
+    secrets:
+      GCP_SERVICE_ACCOUNT:
+        required: true
+      GCP_WORKLOAD_IDENTITY_PROVIDER:
+        required: true
+      GCP_REMOTE_CACHE_BUCKET:
+        required: true
 
 jobs:
   build-binaries:
     runs-on: ubuntu-latest
     container:
       image: overfoundation/bazel-cross:latest
+    permissions:
+      id-token: write # Allows the workflow to request an OIDC token
+      contents: read
     steps:
       - uses: actions/checkout@v3
+
+      - uses: "google-github-actions/auth@v2"
+        with:
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+
       - name: Git config
         run: |
           git config --global --add safe.directory /__w/chronos/chronos
@@ -29,6 +45,9 @@ jobs:
           bazel build \
             --config=release \
             --config=${{ inputs.build-type }} \
+            --remote_cache=https://storage.googleapis.com/${{ secrets.GCP_REMOTE_CACHE_BUCKET }}/ \
+            --remote_upload_local_results \
+            --google_default_credentials \
             //cmd/beacon-chain \
             //cmd/validator \
             //cmd/prysmctl \

--- a/.github/workflows/_build-bazel.yml
+++ b/.github/workflows/_build-bazel.yml
@@ -29,19 +29,18 @@ jobs:
       id-token: write # Allows the workflow to request an OIDC token
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: "google-github-actions/auth@v2"
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          create_credentials_file: true
 
       - name: "Set up Cloud SDK"
         uses: "google-github-actions/setup-gcloud@v2"
-
-      - name: "List buckets"
-        run: |
-          gcloud storage ls
+        with:
+          version: ">= 390.0.0"
 
       - name: Git config
         run: |

--- a/.github/workflows/_build-bazel.yml
+++ b/.github/workflows/_build-bazel.yml
@@ -17,8 +17,6 @@ on:
         required: true
       GCP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
-      GCP_REMOTE_CACHE_BUCKET:
-        required: true
 
 jobs:
   build-binaries:
@@ -51,9 +49,7 @@ jobs:
           bazel build \
             --config=release \
             --config=${{ inputs.build-type }} \
-            --remote_cache=https://storage.googleapis.com/${{ secrets.GCP_REMOTE_CACHE_BUCKET }}/ \
-            --remote_upload_local_results \
-            --google_default_credentials \
+            --config=remote-cache \
             //cmd/beacon-chain \
             //cmd/validator \
             //cmd/prysmctl \

--- a/.github/workflows/_build-bazel.yml
+++ b/.github/workflows/_build-bazel.yml
@@ -31,10 +31,17 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: "google-github-actions/auth@v2"
+      - uses: "google-github-actions/auth@v0"
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v0"
+
+      - name: "List buckets"
+        run: |
+          gcloud storage ls
 
       - name: Git config
         run: |

--- a/.github/workflows/_build-bazel.yml
+++ b/.github/workflows/_build-bazel.yml
@@ -31,13 +31,13 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: "google-github-actions/auth@v0"
+      - uses: "google-github-actions/auth@v2"
         with:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
 
       - name: "Set up Cloud SDK"
-        uses: "google-github-actions/setup-gcloud@v0"
+        uses: "google-github-actions/setup-gcloud@v2"
 
       - name: "List buckets"
         run: |

--- a/.github/workflows/_build-docker.yml
+++ b/.github/workflows/_build-docker.yml
@@ -14,6 +14,12 @@ on:
         required: true
       DOCKERHUB_TOKEN:
         required: true
+      GCP_SERVICE_ACCOUNT:
+        required: true
+      GCP_WORKLOAD_IDENTITY_PROVIDER:
+        required: true
+      GCP_REMOTE_CACHE_BUCKET:
+        required: true
 
 jobs:
   build-and-push-images:
@@ -23,7 +29,19 @@ jobs:
     outputs:
       docker_tag: ${{ steps.set-docker-tag.outputs.docker_tag }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+
+      - uses: "google-github-actions/auth@v2"
+        with:
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          create_credentials_file: true
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v2"
+        with:
+          version: ">= 390.0.0"
+
       - name: Git config
         run: |
           git config --global --add safe.directory /__w/chronos/chronos
@@ -45,6 +63,9 @@ jobs:
           bazel run \
             //cmd/beacon-chain:push_images \
             --config=release \
+            --remote_cache=https://storage.googleapis.com/${{ secrets.GCP_REMOTE_CACHE_BUCKET }}/ \
+            --remote_upload_local_results \
+            --google_default_credentials \
             -- \
             --tag=${{ steps.set-docker-tag.outputs.docker_tag }} \
             --repository=overfoundation/chronos-beacon-chain
@@ -55,6 +76,9 @@ jobs:
           bazel run \
             //cmd/validator:push_images \
             --config=release \
+            --remote_cache=https://storage.googleapis.com/${{ secrets.GCP_REMOTE_CACHE_BUCKET }}/ \
+            --remote_upload_local_results \
+            --google_default_credentials \
             -- \
             --tag=${{ steps.set-docker-tag.outputs.docker_tag }} \
             --repository=overfoundation/chronos-validator
@@ -66,6 +90,9 @@ jobs:
           bazel run \
             //cmd/beacon-chain:push_images \
             --config=release \
+            --remote_cache=https://storage.googleapis.com/${{ secrets.GCP_REMOTE_CACHE_BUCKET }}/ \
+            --remote_upload_local_results \
+            --google_default_credentials \
             -- \
             --tag=latest \
             --repository=overfoundation/chronos-beacon-chain
@@ -73,6 +100,9 @@ jobs:
           bazel run \
             //cmd/validator:push_images \
             --config=release \
+            --remote_cache=https://storage.googleapis.com/${{ secrets.GCP_REMOTE_CACHE_BUCKET }}/ \
+            --remote_upload_local_results \
+            --google_default_credentials \
             -- \
             --tag=latest \
             --repository=overfoundation/chronos-validator

--- a/.github/workflows/_build-docker.yml
+++ b/.github/workflows/_build-docker.yml
@@ -18,8 +18,6 @@ on:
         required: true
       GCP_WORKLOAD_IDENTITY_PROVIDER:
         required: true
-      GCP_REMOTE_CACHE_BUCKET:
-        required: true
 
 jobs:
   build-and-push-images:
@@ -63,9 +61,7 @@ jobs:
           bazel run \
             //cmd/beacon-chain:push_images \
             --config=release \
-            --remote_cache=https://storage.googleapis.com/${{ secrets.GCP_REMOTE_CACHE_BUCKET }}/ \
-            --remote_upload_local_results \
-            --google_default_credentials \
+            --config=remote-cache \
             -- \
             --tag=${{ steps.set-docker-tag.outputs.docker_tag }} \
             --repository=overfoundation/chronos-beacon-chain
@@ -76,9 +72,7 @@ jobs:
           bazel run \
             //cmd/validator:push_images \
             --config=release \
-            --remote_cache=https://storage.googleapis.com/${{ secrets.GCP_REMOTE_CACHE_BUCKET }}/ \
-            --remote_upload_local_results \
-            --google_default_credentials \
+            --config=remote-cache \
             -- \
             --tag=${{ steps.set-docker-tag.outputs.docker_tag }} \
             --repository=overfoundation/chronos-validator
@@ -90,9 +84,7 @@ jobs:
           bazel run \
             //cmd/beacon-chain:push_images \
             --config=release \
-            --remote_cache=https://storage.googleapis.com/${{ secrets.GCP_REMOTE_CACHE_BUCKET }}/ \
-            --remote_upload_local_results \
-            --google_default_credentials \
+            --config=remote-cache \
             -- \
             --tag=latest \
             --repository=overfoundation/chronos-beacon-chain
@@ -100,9 +92,7 @@ jobs:
           bazel run \
             //cmd/validator:push_images \
             --config=release \
-            --remote_cache=https://storage.googleapis.com/${{ secrets.GCP_REMOTE_CACHE_BUCKET }}/ \
-            --remote_upload_local_results \
-            --google_default_credentials \
+            --config=remote-cache \
             -- \
             --tag=latest \
             --repository=overfoundation/chronos-validator

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -121,6 +121,9 @@ jobs:
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_REMOTE_CACHE_BUCKET: ${{ secrets.GCP_REMOTE_CACHE_BUCKET }}
 
   create-release:
     needs: [build, extract-version]

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -14,9 +14,6 @@ jobs:
     outputs:
       tag_name: ${{ steps.extract.outputs.tag_name }}
       version_name: ${{ steps.extract.outputs.version_name }}
-    permissions:
-      id-token: write
-      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Extract tag name, version
@@ -27,21 +24,6 @@ jobs:
           tag_name="${full_tag#*_}"
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
           echo "version_name=$version_name" >> $GITHUB_OUTPUT
-
-      # Temp
-      - uses: "google-github-actions/auth@v2"
-        with:
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          create_credentials_file: true
-
-      - name: "Set up Cloud SDK"
-        uses: "google-github-actions/setup-gcloud@v2"
-        with:
-          version: ">= 390.0.0"
-
-      - name: "Use gcloud CLI"
-        run: "gcloud info"
 
   build:
     needs: extract-version

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -25,6 +25,21 @@ jobs:
           echo "tag_name=$tag_name" >> $GITHUB_OUTPUT
           echo "version_name=$version_name" >> $GITHUB_OUTPUT
 
+      # Temp
+      - uses: "google-github-actions/auth@v2"
+        with:
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          create_credentials_file: true
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v2"
+        with:
+          version: ">= 390.0.0"
+
+      - name: "Use gcloud CLI"
+        run: "gcloud info"
+
   build:
     needs: extract-version
     strategy:

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -36,6 +36,10 @@ jobs:
       build-type: ${{ matrix.symbol-list }}
       tag_name: ${{ needs.extract-version.outputs.tag_name }}
       version_name: ${{ needs.extract-version.outputs.version_name }}
+    secrets:
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+      GCP_REMOTE_CACHE_BUCKET: ${{ secrets.GCP_REMOTE_CACHE_BUCKET }}
 
   upload-aws:
     needs: [build, extract-version]

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -36,6 +36,9 @@ jobs:
       build-type: ${{ matrix.symbol-list }}
       tag_name: ${{ needs.extract-version.outputs.tag_name }}
       version_name: ${{ needs.extract-version.outputs.version_name }}
+    permissions:
+      id-token: write
+      contents: read
     secrets:
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -118,6 +118,9 @@ jobs:
     with:
       tag_name: ${{ needs.extract-version.outputs.tag_name }}
       version_name: ${{ needs.extract-version.outputs.version_name }}
+    permissions:
+      id-token: write
+      contents: read
     secrets:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Extract tag name, version
         id: extract
         run: |

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -42,7 +42,6 @@ jobs:
     secrets:
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_REMOTE_CACHE_BUCKET: ${{ secrets.GCP_REMOTE_CACHE_BUCKET }}
 
   upload-aws:
     needs: [build, extract-version]
@@ -126,7 +125,6 @@ jobs:
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
       GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
       GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-      GCP_REMOTE_CACHE_BUCKET: ${{ secrets.GCP_REMOTE_CACHE_BUCKET }}
 
   create-release:
     needs: [build, extract-version]

--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -14,6 +14,9 @@ jobs:
     outputs:
       tag_name: ${{ steps.extract.outputs.tag_name }}
       version_name: ${{ steps.extract.outputs.version_name }}
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - name: Extract tag name, version

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ tmp
 
 # spectest coverage reports
 report.txt
+
+# Ignore generated credentials from google-github-actions/auth
+gha-creds-*.json


### PR DESCRIPTION
<img width="500" alt="image" src="https://github.com/user-attachments/assets/7116eb07-73da-416d-9b0c-42981f6f9e48">

---

```
INFO: 4363 processes: 4057 remote cache hit, 298 internal, 8 processwrapper-sandbox.
```

As Bazel supports [Remote Caching](https://bazel.build/remote/caching), our workflow for build could be much faster and reusable. This PR adds `remote-cache` flag in `.bazelrc`, so that build processes take much faster. (It takes about ~10 minutes per each job, which was a huge improvement than ~25 minutes.)

As managing long-lived credentials for GCP service account is not recommended([GCP blog](https://cloud.google.com/blog/products/identity-security/enabling-keyless-authentication-from-github-actions?hl=en)), I leveraged Workload Identitiy Federation to authenticate each workflow to access our remote caching server. `GCP_WORKLOAD_IDENTITY_PROVIDER` contains its provider. 