### PR TITLE
Disable validator prefixes

### DIFF
--- a/beacon-chain/core/electra/deposits.go
+++ b/beacon-chain/core/electra/deposits.go
@@ -97,32 +97,35 @@ func ProcessDeposit(beaconState state.BeaconState, deposit *ethpb.Deposit, allSi
 // ApplyDeposit adds the incoming deposit as a pending deposit on the state
 //
 // Spec pseudocode definition:
-// def apply_deposit(
+// def apply_deposit(state: BeaconState,
 //
-//	state: BeaconState,
-//	pubkey: BLSPubkey,
-//	withdrawal_credentials: Bytes32,
-//	amount: uint64,
-//	signature: BLSSignature,
-//
-// ) -> None:
-//
+//	              pubkey: BLSPubkey,
+//	              withdrawal_credentials: Bytes32,
+//	              amount: uint64,
+//	              signature: BLSSignature) -> None:
 //	validator_pubkeys = [v.pubkey for v in state.validators]
 //	if pubkey not in validator_pubkeys:
 //	    # Verify the deposit signature (proof of possession) which is not checked by the deposit contract
 //	    if is_valid_deposit_signature(pubkey, withdrawal_credentials, amount, signature):
-//	        add_validator_to_registry(state, pubkey, withdrawal_credentials, amount)
+//	        add_validator_to_registry(state, pubkey, withdrawal_credentials, Gwei(0))  # [Modified in Electra:EIP7251]
+//	        # [New in Electra:EIP7251]
+//	        state.pending_deposits.append(PendingDeposit(
+//	            pubkey=pubkey,
+//	            withdrawal_credentials=withdrawal_credentials,
+//	            amount=amount,
+//	            signature=signature,
+//	            slot=GENESIS_SLOT,  # Use GENESIS_SLOT to distinguish from a pending deposit request
+//	        ))
 //	else:
 //	    # Increase balance by deposit amount
-//	    index = ValidatorIndex(validator_pubkeys.index(pubkey))
-//	    state.pending_balance_deposits.append(PendingBalanceDeposit(index=index, amount=amount))  # [Modified in Electra:EIP7251]
-//	    # Check if valid deposit switch to compounding credentials
-//	    if (
-//	        is_compounding_withdrawal_credential(withdrawal_credentials)
-//	        and has_eth1_withdrawal_credential(state.validators[index])
-//	        and is_valid_deposit_signature(pubkey, withdrawal_credentials, amount, signature)
-//	    ):
-//	        switch_to_compounding_validator(state, index)
+//	    # [Modified in Electra:EIP7251]
+//	    state.pending_deposits.append(PendingDeposit(
+//	        pubkey=pubkey,
+//	        withdrawal_credentials=withdrawal_credentials,
+//	        amount=amount,
+//	        signature=signature,
+//	        slot=GENESIS_SLOT  # Use GENESIS_SLOT to distinguish from a pending deposit request
+//	    ))
 func ApplyDeposit(beaconState state.BeaconState, data *ethpb.Deposit_Data, allSignaturesVerified bool) (state.BeaconState, error) {
 	pubKey := data.PublicKey
 	amount := data.Amount

--- a/beacon-chain/core/electra/upgrade.go
+++ b/beacon-chain/core/electra/upgrade.go
@@ -111,11 +111,6 @@ import (
 //	for index in pre_activation:
 //	    queue_entire_balance_and_reset_validator(post, ValidatorIndex(index))
 //
-//	# Ensure early adopters of compounding credentials go through the activation churn
-//	for index, validator in enumerate(post.validators):
-//	    if has_compounding_withdrawal_credential(validator):
-//	        queue_excess_active_balance(post, ValidatorIndex(index))
-//
 //	return post
 func UpgradeToElectra(beaconState state.BeaconState) (state.BeaconState, error) {
 	prevEpochParticipation, err := beaconState.PreviousEpochParticipation()

--- a/beacon-chain/core/electra/validator.go
+++ b/beacon-chain/core/electra/validator.go
@@ -1,39 +1,12 @@
 package electra
 
 import (
-	"errors"
-
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/crypto/bls/common"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
 )
-
-// SwitchToCompoundingValidator
-//
-// Spec definition:
-//
-// def switch_to_compounding_validator(state: BeaconState, index: ValidatorIndex) -> None:
-//
-//	validator = state.validators[index]
-//	validator.withdrawal_credentials = COMPOUNDING_WITHDRAWAL_PREFIX + validator.withdrawal_credentials[1:]
-//	queue_excess_active_balance(state, index)
-func SwitchToCompoundingValidator(s state.BeaconState, idx primitives.ValidatorIndex) error {
-	v, err := s.ValidatorAtIndex(idx)
-	if err != nil {
-		return err
-	}
-	if len(v.WithdrawalCredentials) == 0 {
-		return errors.New("validator has no withdrawal credentials")
-	}
-
-	v.WithdrawalCredentials[0] = params.BeaconConfig().CompoundingWithdrawalPrefixByte
-	if err := s.UpdateValidatorAtIndex(idx, v); err != nil {
-		return err
-	}
-	return QueueExcessActiveBalance(s, idx)
-}
 
 // QueueExcessActiveBalance queues validators with balances above the min activation balance and adds to pending deposit.
 //

--- a/beacon-chain/core/electra/validator_test.go
+++ b/beacon-chain/core/electra/validator_test.go
@@ -1,7 +1,6 @@
 package electra_test
 
 import (
-	"bytes"
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/electra"
@@ -12,53 +11,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/testing/require"
 	"github.com/prysmaticlabs/prysm/v5/testing/util"
 )
-
-func TestSwitchToCompoundingValidator(t *testing.T) {
-	s, err := state_native.InitializeFromProtoElectra(&eth.BeaconStateElectra{
-		Validators: []*eth.Validator{
-			{
-				WithdrawalCredentials: []byte{}, // No withdrawal credentials
-			},
-			{
-				WithdrawalCredentials: []byte{0x01, 0xFF}, // Has withdrawal credentials
-			},
-			{
-				WithdrawalCredentials: []byte{0x01, 0xFF}, // Has withdrawal credentials
-			},
-		},
-		Balances: []uint64{
-			params.BeaconConfig().MinActivationBalance,
-			params.BeaconConfig().MinActivationBalance,
-			params.BeaconConfig().MinActivationBalance + 100_000, // Has excess balance
-		},
-	})
-	// Test that a validator with no withdrawal credentials cannot be switched to compounding.
-	require.NoError(t, err)
-	require.ErrorContains(t, "validator has no withdrawal credentials", electra.SwitchToCompoundingValidator(s, 0))
-
-	// Test that a validator with withdrawal credentials can be switched to compounding.
-	require.NoError(t, electra.SwitchToCompoundingValidator(s, 1))
-	v, err := s.ValidatorAtIndex(1)
-	require.NoError(t, err)
-	require.Equal(t, true, bytes.HasPrefix(v.WithdrawalCredentials, []byte{params.BeaconConfig().CompoundingWithdrawalPrefixByte}), "withdrawal credentials were not updated")
-	// val_1 Balance is not changed
-	b, err := s.BalanceAtIndex(1)
-	require.NoError(t, err)
-	require.Equal(t, params.BeaconConfig().MinActivationBalance, b, "balance was changed")
-	pbd, err := s.PendingDeposits()
-	require.NoError(t, err)
-	require.Equal(t, 0, len(pbd), "pending balance deposits should be empty")
-
-	// Test that a validator with excess balance can be switched to compounding, excess balance is queued.
-	require.NoError(t, electra.SwitchToCompoundingValidator(s, 2))
-	b, err = s.BalanceAtIndex(2)
-	require.NoError(t, err)
-	require.Equal(t, params.BeaconConfig().MinActivationBalance, b, "balance was not changed")
-	pbd, err = s.PendingDeposits()
-	require.NoError(t, err)
-	require.Equal(t, 1, len(pbd), "pending balance deposits should have one element")
-	require.Equal(t, uint64(100_000), pbd[0].Amount, "pending balance deposit amount is incorrect")
-}
 
 func TestQueueEntireBalanceAndResetValidator(t *testing.T) {
 	s, err := state_native.InitializeFromProtoElectra(&eth.BeaconStateElectra{
@@ -85,25 +37,6 @@ func TestQueueEntireBalanceAndResetValidator(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, len(pbd), "pending balance deposits should have one element")
 	require.Equal(t, params.BeaconConfig().MinActivationBalance+100_000, pbd[0].Amount, "pending balance deposit amount is incorrect")
-}
-
-func TestSwitchToCompoundingValidator_Ok(t *testing.T) {
-	st, _ := util.DeterministicGenesisStateElectra(t, params.BeaconConfig().MaxValidatorsPerCommittee)
-	vals := st.Validators()
-	vals[0].WithdrawalCredentials = []byte{params.BeaconConfig().ETH1AddressWithdrawalPrefixByte}
-	require.NoError(t, st.SetValidators(vals))
-	bals := st.Balances()
-	bals[0] = params.BeaconConfig().MinActivationBalance + 1010
-	require.NoError(t, st.SetBalances(bals))
-	require.NoError(t, electra.SwitchToCompoundingValidator(st, 0))
-
-	pbd, err := st.PendingDeposits()
-	require.NoError(t, err)
-	require.Equal(t, uint64(1010), pbd[0].Amount) // appends it at the end
-	val, err := st.ValidatorAtIndex(0)
-	require.NoError(t, err)
-
-	bytes.HasPrefix(val.WithdrawalCredentials, []byte{params.BeaconConfig().CompoundingWithdrawalPrefixByte})
 }
 
 func TestQueueExcessActiveBalance_Ok(t *testing.T) {

--- a/beacon-chain/core/electra/withdrawals.go
+++ b/beacon-chain/core/electra/withdrawals.go
@@ -24,11 +24,6 @@ import (
 //
 // Spec pseudocode definition:
 //
-// ProcessWithdrawalRequests processes the validator withdrawals from the provided execution payload
-// into the beacon state triggered by the execution layer.
-//
-// Spec pseudocode definition:
-//
 // def process_withdrawal_request(
 //
 //	state: BeaconState,

--- a/beacon-chain/core/electra/withdrawals.go
+++ b/beacon-chain/core/electra/withdrawals.go
@@ -24,69 +24,63 @@ import (
 //
 // Spec pseudocode definition:
 //
-// def process_withdrawal_request(
+// def process_withdrawal_request(state: BeaconState, withdrawal_request: WithdrawalRequest) -> None:
+//     amount = withdrawal_request.amount
+//     is_full_exit_request = amount == FULL_EXIT_REQUEST_AMOUNT
+
+//     # If partial withdrawal queue is full, only full exits are processed
+//     if len(state.pending_partial_withdrawals) == PENDING_PARTIAL_WITHDRAWALS_LIMIT and not is_full_exit_request:
+//         return
+
+//     validator_pubkeys = [v.pubkey for v in state.validators]
+//     # Verify pubkey exists
+//     request_pubkey = withdrawal_request.validator_pubkey
+//     if request_pubkey not in validator_pubkeys:
+//         return
+//     index = ValidatorIndex(validator_pubkeys.index(request_pubkey))
+//     validator = state.validators[index]
+
+//     # Verify withdrawal credentials
+//     is_correct_source_address = validator.withdrawal_credentials[12:] == withdrawal_request.source_address
+//     if not is_correct_source_address:
+//         return
+//     # Verify the validator is active
+//     if not is_active_validator(validator, get_current_epoch(state)):
+//         return
+//     # Verify exit has not been initiated
+//     if validator.exit_epoch != FAR_FUTURE_EPOCH:
+//         return
+//     # Verify the validator has been active long enough
+//     if get_current_epoch(state) < validator.activation_epoch + SHARD_COMMITTEE_PERIOD:
+//         return
+
+//     pending_balance_to_withdraw = get_pending_balance_to_withdraw(state, index)
+
+//     if is_full_exit_request:
+//         # Only exit validator if it has no pending withdrawals in the queue
+//         if pending_balance_to_withdraw == 0:
+//             initiate_validator_exit(state, index)
+//         return
+
+//     has_sufficient_effective_balance = validator.effective_balance >= MIN_ACTIVATION_BALANCE
+//     has_excess_balance = state.balances[index] > MIN_ACTIVATION_BALANCE + pending_balance_to_withdraw
+
+// # Only allow partial withdrawals with compounding withdrawal credentials
+// if has_sufficient_effective_balance and has_excess_balance:
 //
-//	state: BeaconState,
-//	withdrawal_request: WithdrawalRequest
-//
-// ) -> None:
-//
-//	amount = withdrawal_request.amount
-//	is_full_exit_request = amount == FULL_EXIT_REQUEST_AMOUNT
-//
-//	# If partial withdrawal queue is full, only full exits are processed
-//	if len(state.pending_partial_withdrawals) == PENDING_PARTIAL_WITHDRAWALS_LIMIT and not is_full_exit_request:
-//	    return
-//
-//	validator_pubkeys = [v.pubkey for v in state.validators]
-//	# Verify pubkey exists
-//	request_pubkey = withdrawal_request.validator_pubkey
-//	if request_pubkey not in validator_pubkeys:
-//	    return
-//	index = ValidatorIndex(validator_pubkeys.index(request_pubkey))
-//	validator = state.validators[index]
-//
-//	# Verify withdrawal credentials
-//	has_correct_credential = has_execution_withdrawal_credential(validator)
-//	is_correct_source_address = (
-//	    validator.withdrawal_credentials[12:] == withdrawal_request.source_address
+//	to_withdraw = min(
+//	    state.balances[index] - MIN_ACTIVATION_BALANCE - pending_balance_to_withdraw,
+//	    amount,
 //	)
-//	if not (has_correct_credential and is_correct_source_address):
-//	    return
-//	# Verify the validator is active
-//	if not is_active_validator(validator, get_current_epoch(state)):
-//	    return
-//	# Verify exit has not been initiated
-//	if validator.exit_epoch != FAR_FUTURE_EPOCH:
-//	    return
-//	# Verify the validator has been active long enough
-//	if get_current_epoch(state) < validator.activation_epoch + SHARD_COMMITTEE_PERIOD:
-//	    return
-//
-//	pending_balance_to_withdraw = get_pending_balance_to_withdraw(state, index)
-//
-//	if is_full_exit_request:
-//	    # Only exit validator if it has no pending withdrawals in the queue
-//	    if pending_balance_to_withdraw == 0:
-//	        initiate_validator_exit(state, index)
-//	    return
-//
-//	has_sufficient_effective_balance = validator.effective_balance >= MIN_ACTIVATION_BALANCE
-//	has_excess_balance = state.balances[index] > MIN_ACTIVATION_BALANCE + pending_balance_to_withdraw
-//
-//	# Only allow partial withdrawals with compounding withdrawal credentials
-//	if has_compounding_withdrawal_credential(validator) and has_sufficient_effective_balance and has_excess_balance:
-//	    to_withdraw = min(
-//	        state.balances[index] - MIN_ACTIVATION_BALANCE - pending_balance_to_withdraw,
-//	        amount
-//	    )
-//	    exit_queue_epoch = compute_exit_epoch_and_update_churn(state, to_withdraw)
-//	    withdrawable_epoch = Epoch(exit_queue_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
-//	    state.pending_partial_withdrawals.append(PendingPartialWithdrawal(
+//	exit_queue_epoch = compute_exit_epoch_and_update_churn(state, to_withdraw)
+//	withdrawable_epoch = Epoch(exit_queue_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
+//	state.pending_partial_withdrawals.append(
+//	    PendingPartialWithdrawal(
 //	        index=index,
 //	        amount=to_withdraw,
 //	        withdrawable_epoch=withdrawable_epoch,
-//	    ))
+//	    )
+//	)
 func ProcessWithdrawalRequests(ctx context.Context, st state.BeaconState, wrs []*enginev1.WithdrawalRequest) (state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "electra.ProcessWithdrawalRequests")
 	defer span.End()
@@ -116,9 +110,8 @@ func ProcessWithdrawalRequests(ctx context.Context, st state.BeaconState, wrs []
 			return nil, err
 		}
 		// Verify withdrawal credentials
-		hasCorrectCredential := helpers.HasExecutionWithdrawalCredentials(validator)
 		isCorrectSourceAddress := bytes.Equal(validator.WithdrawalCredentials[12:], wr.SourceAddress)
-		if !hasCorrectCredential || !isCorrectSourceAddress {
+		if !isCorrectSourceAddress {
 			log.Debugln("Skipping execution layer withdrawal request, wrong withdrawal credentials")
 			continue
 		}
@@ -164,7 +157,7 @@ func ProcessWithdrawalRequests(ctx context.Context, st state.BeaconState, wrs []
 		hasExcessBalance := vBal > params.BeaconConfig().MinActivationBalance+pendingBalanceToWithdraw
 
 		// Only allow partial withdrawals with compounding withdrawal credentials
-		if helpers.HasCompoundingWithdrawalCredential(validator) && hasSufficientEffectiveBalance && hasExcessBalance {
+		if hasSufficientEffectiveBalance && hasExcessBalance {
 			// Spec definition:
 			//  to_withdraw = min(
 			//	  state.balances[index] - MIN_ACTIVATION_BALANCE - pending_balance_to_withdraw,

--- a/beacon-chain/core/electra/withdrawals.go
+++ b/beacon-chain/core/electra/withdrawals.go
@@ -24,63 +24,73 @@ import (
 //
 // Spec pseudocode definition:
 //
-// def process_withdrawal_request(state: BeaconState, withdrawal_request: WithdrawalRequest) -> None:
-//     amount = withdrawal_request.amount
-//     is_full_exit_request = amount == FULL_EXIT_REQUEST_AMOUNT
-
-//     # If partial withdrawal queue is full, only full exits are processed
-//     if len(state.pending_partial_withdrawals) == PENDING_PARTIAL_WITHDRAWALS_LIMIT and not is_full_exit_request:
-//         return
-
-//     validator_pubkeys = [v.pubkey for v in state.validators]
-//     # Verify pubkey exists
-//     request_pubkey = withdrawal_request.validator_pubkey
-//     if request_pubkey not in validator_pubkeys:
-//         return
-//     index = ValidatorIndex(validator_pubkeys.index(request_pubkey))
-//     validator = state.validators[index]
-
-//     # Verify withdrawal credentials
-//     is_correct_source_address = validator.withdrawal_credentials[12:] == withdrawal_request.source_address
-//     if not is_correct_source_address:
-//         return
-//     # Verify the validator is active
-//     if not is_active_validator(validator, get_current_epoch(state)):
-//         return
-//     # Verify exit has not been initiated
-//     if validator.exit_epoch != FAR_FUTURE_EPOCH:
-//         return
-//     # Verify the validator has been active long enough
-//     if get_current_epoch(state) < validator.activation_epoch + SHARD_COMMITTEE_PERIOD:
-//         return
-
-//     pending_balance_to_withdraw = get_pending_balance_to_withdraw(state, index)
-
-//     if is_full_exit_request:
-//         # Only exit validator if it has no pending withdrawals in the queue
-//         if pending_balance_to_withdraw == 0:
-//             initiate_validator_exit(state, index)
-//         return
-
-//     has_sufficient_effective_balance = validator.effective_balance >= MIN_ACTIVATION_BALANCE
-//     has_excess_balance = state.balances[index] > MIN_ACTIVATION_BALANCE + pending_balance_to_withdraw
-
-// # Only allow partial withdrawals with compounding withdrawal credentials
-// if has_sufficient_effective_balance and has_excess_balance:
+// ProcessWithdrawalRequests processes the validator withdrawals from the provided execution payload
+// into the beacon state triggered by the execution layer.
 //
-//	to_withdraw = min(
-//	    state.balances[index] - MIN_ACTIVATION_BALANCE - pending_balance_to_withdraw,
-//	    amount,
+// Spec pseudocode definition:
+//
+// def process_withdrawal_request(
+//
+//	state: BeaconState,
+//	withdrawal_request: WithdrawalRequest
+//
+// ) -> None:
+//
+//	amount = withdrawal_request.amount
+//	is_full_exit_request = amount == FULL_EXIT_REQUEST_AMOUNT
+//
+//	# If partial withdrawal queue is full, only full exits are processed
+//	if len(state.pending_partial_withdrawals) == PENDING_PARTIAL_WITHDRAWALS_LIMIT and not is_full_exit_request:
+//	    return
+//
+//	validator_pubkeys = [v.pubkey for v in state.validators]
+//	# Verify pubkey exists
+//	request_pubkey = withdrawal_request.validator_pubkey
+//	if request_pubkey not in validator_pubkeys:
+//	    return
+//	index = ValidatorIndex(validator_pubkeys.index(request_pubkey))
+//	validator = state.validators[index]
+//
+//	# Verify withdrawal credentials
+//	has_correct_credential = has_execution_withdrawal_credential(validator)
+//	is_correct_source_address = (
+//	    validator.withdrawal_credentials[12:] == withdrawal_request.source_address
 //	)
-//	exit_queue_epoch = compute_exit_epoch_and_update_churn(state, to_withdraw)
-//	withdrawable_epoch = Epoch(exit_queue_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
-//	state.pending_partial_withdrawals.append(
-//	    PendingPartialWithdrawal(
+//	if not is_correct_source_address:
+//	    return
+//	# Verify the validator is active
+//	if not is_active_validator(validator, get_current_epoch(state)):
+//	    return
+//	# Verify exit has not been initiated
+//	if validator.exit_epoch != FAR_FUTURE_EPOCH:
+//	    return
+//	# Verify the validator has been active long enough
+//	if get_current_epoch(state) < validator.activation_epoch + SHARD_COMMITTEE_PERIOD:
+//	    return
+//
+//	pending_balance_to_withdraw = get_pending_balance_to_withdraw(state, index)
+//
+//	if is_full_exit_request:
+//	    # Only exit validator if it has no pending withdrawals in the queue
+//	    if pending_balance_to_withdraw == 0:
+//	        initiate_validator_exit(state, index)
+//	    return
+//
+//	has_sufficient_effective_balance = validator.effective_balance >= MIN_ACTIVATION_BALANCE
+//	has_excess_balance = state.balances[index] > MIN_ACTIVATION_BALANCE + pending_balance_to_withdraw
+//
+//	if has_sufficient_effective_balance and has_excess_balance:
+//	    to_withdraw = min(
+//	        state.balances[index] - MIN_ACTIVATION_BALANCE - pending_balance_to_withdraw,
+//	        amount
+//	    )
+//	    exit_queue_epoch = compute_exit_epoch_and_update_churn(state, to_withdraw)
+//	    withdrawable_epoch = Epoch(exit_queue_epoch + MIN_VALIDATOR_WITHDRAWABILITY_DELAY)
+//	    state.pending_partial_withdrawals.append(PendingPartialWithdrawal(
 //	        index=index,
 //	        amount=to_withdraw,
 //	        withdrawable_epoch=withdrawable_epoch,
-//	    )
-//	)
+//	    ))
 func ProcessWithdrawalRequests(ctx context.Context, st state.BeaconState, wrs []*enginev1.WithdrawalRequest) (state.BeaconState, error) {
 	ctx, span := trace.StartSpan(ctx, "electra.ProcessWithdrawalRequests")
 	defer span.End()

--- a/beacon-chain/core/helpers/BUILD.bazel
+++ b/beacon-chain/core/helpers/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//beacon-chain/state:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",
-        "//consensus-types/interfaces:go_default_library",
         "//consensus-types/primitives:go_default_library",
         "//container/slice:go_default_library",
         "//container/trie:go_default_library",

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -594,7 +594,7 @@ func IsFullyWithdrawableValidator(val *ethpb.Validator, balance uint64, epoch pr
 		return false
 	}
 	withdrawableEpoch := GetWithdrawableEpoch(val.ExitEpoch, val.Slashed)
-	return withdrawableEpoch <= epoch && balance > 0
+	return withdrawableEpoch <= epoch
 }
 
 // IsPartiallyWithdrawableValidator returns whether the validator is able to perform a

--- a/beacon-chain/core/helpers/validators.go
+++ b/beacon-chain/core/helpers/validators.go
@@ -12,7 +12,6 @@ import (
 	forkchoicetypes "github.com/prysmaticlabs/prysm/v5/beacon-chain/forkchoice/types"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
-	"github.com/prysmaticlabs/prysm/v5/consensus-types/interfaces"
 	"github.com/prysmaticlabs/prysm/v5/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v5/crypto/hash"
 	"github.com/prysmaticlabs/prysm/v5/encoding/bytesutil"
@@ -567,63 +566,6 @@ func LastActivatedValidatorIndex(ctx context.Context, st state.ReadOnlyBeaconSta
 	return lastActivatedvalidatorIndex, nil
 }
 
-// hasETH1WithdrawalCredential returns whether the validator has an ETH1
-// Withdrawal prefix. It assumes that the caller has a lock on the state
-func HasETH1WithdrawalCredential(val interfaces.WithWithdrawalCredentials) bool {
-	if val == nil {
-		return false
-	}
-	return isETH1WithdrawalCredential(val.GetWithdrawalCredentials())
-}
-
-func isETH1WithdrawalCredential(creds []byte) bool {
-	return bytes.HasPrefix(creds, []byte{params.BeaconConfig().ETH1AddressWithdrawalPrefixByte})
-}
-
-// HasCompoundingWithdrawalCredential checks if the validator has a compounding withdrawal credential.
-// New in Electra EIP-7251: https://eips.ethereum.org/EIPS/eip-7251
-//
-// Spec definition:
-//
-//	def has_compounding_withdrawal_credential(validator: Validator) -> bool:
-//	    """
-//	    Check if ``validator`` has an 0x02 prefixed "compounding" withdrawal credential.
-//	    """
-//	    return is_compounding_withdrawal_credential(validator.withdrawal_credentials)
-func HasCompoundingWithdrawalCredential(v interfaces.WithWithdrawalCredentials) bool {
-	if v == nil {
-		return false
-	}
-	return IsCompoundingWithdrawalCredential(v.GetWithdrawalCredentials())
-}
-
-// IsCompoundingWithdrawalCredential checks if the credentials are a compounding withdrawal credential.
-//
-// Spec definition:
-//
-//	def is_compounding_withdrawal_credential(withdrawal_credentials: Bytes32) -> bool:
-//	    return withdrawal_credentials[:1] == COMPOUNDING_WITHDRAWAL_PREFIX
-func IsCompoundingWithdrawalCredential(creds []byte) bool {
-	return bytes.HasPrefix(creds, []byte{params.BeaconConfig().CompoundingWithdrawalPrefixByte})
-}
-
-// HasExecutionWithdrawalCredentials checks if the validator has an execution withdrawal credential or compounding credential.
-// New in Electra EIP-7251: https://eips.ethereum.org/EIPS/eip-7251
-//
-// Spec definition:
-//
-//	def has_execution_withdrawal_credential(validator: Validator) -> bool:
-//	    """
-//	    Check if ``validator`` has a 0x01 or 0x02 prefixed withdrawal credential.
-//	    """
-//	    return has_compounding_withdrawal_credential(validator) or has_eth1_withdrawal_credential(validator)
-func HasExecutionWithdrawalCredentials(v interfaces.WithWithdrawalCredentials) bool {
-	if v == nil {
-		return false
-	}
-	return HasCompoundingWithdrawalCredential(v) || HasETH1WithdrawalCredential(v)
-}
-
 // IsSameWithdrawalCredentials returns true if both validators have the same withdrawal credentials.
 //
 //	return a.withdrawal_credentials[12:] == b.withdrawal_credentials[12:]
@@ -646,22 +588,13 @@ func IsSameWithdrawalCredentials(a, b *ethpb.Validator) bool {
 //	    """
 //	    Check if ``validator`` is fully withdrawable.
 //	    """
-//	    return (
-//	        has_execution_withdrawal_credential(validator)  # [Modified in Electra:EIP7251]
-//	        and get_withdrawable_epoch(validator) <= epoch
-//	        and balance > 0
-//	    )
+//		return validator.withdrawable_epoch <= epoch and balance > 0  # [Modified in Electra:EIP7251]
 func IsFullyWithdrawableValidator(val *ethpb.Validator, balance uint64, epoch primitives.Epoch, fork int) bool {
 	if val == nil || balance <= 0 {
 		return false
 	}
 	withdrawableEpoch := GetWithdrawableEpoch(val.ExitEpoch, val.Slashed)
-	// Electra / EIP-7251 logic
-	if fork >= version.Electra {
-		return HasExecutionWithdrawalCredentials(val) && withdrawableEpoch <= epoch
-	}
-
-	return HasETH1WithdrawalCredential(val) && withdrawableEpoch <= epoch
+	return withdrawableEpoch <= epoch && balance > 0
 }
 
 // IsPartiallyWithdrawableValidator returns whether the validator is able to perform a
@@ -671,7 +604,6 @@ func IsPartiallyWithdrawableValidator(val *ethpb.Validator, balance uint64, epoc
 	if val == nil {
 		return false
 	}
-
 	return IsPartiallyWithdrawableValidatorAlpaca(val, balance)
 }
 
@@ -689,25 +621,6 @@ func IsPartiallyWithdrawableValidator(val *ethpb.Validator, balance uint64, epoc
 func IsPartiallyWithdrawableValidatorAlpaca(val *ethpb.Validator, balance uint64) bool {
 	hasExcessBalance := balance > val.PrincipalBalance
 	return hasExcessBalance
-}
-
-// ValidatorMaxEffectiveBalance returns the maximum effective balance for a validator.
-//
-// Spec definition:
-//
-//	def get_validator_max_effective_balance(validator: Validator) -> Gwei:
-//	    """
-//	    Get max effective balance for ``validator``.
-//	    """
-//	    if has_compounding_withdrawal_credential(validator):
-//	        return MAX_EFFECTIVE_BALANCE_ALPACA
-//	    else:
-//	        return MIN_ACTIVATION_BALANCE
-func ValidatorMaxEffectiveBalance(val *ethpb.Validator) uint64 {
-	if HasCompoundingWithdrawalCredential(val) {
-		return params.BeaconConfig().MaxEffectiveBalanceAlpaca
-	}
-	return params.BeaconConfig().MinActivationBalance
 }
 
 // GetWithdrawableEpoch returns the epoch at which the validator can withdraw.

--- a/beacon-chain/core/helpers/validators_test.go
+++ b/beacon-chain/core/helpers/validators_test.go
@@ -1013,63 +1013,6 @@ func TestProposerIndexFromCheckpoint(t *testing.T) {
 	require.Equal(t, ids[5], id)
 }
 
-func TestHasETH1WithdrawalCredentials(t *testing.T) {
-	creds := []byte{0xFA, 0xCC}
-	v := &ethpb.Validator{WithdrawalCredentials: creds}
-	require.Equal(t, false, helpers.HasETH1WithdrawalCredential(v))
-	creds = []byte{params.BeaconConfig().ETH1AddressWithdrawalPrefixByte, 0xCC}
-	v = &ethpb.Validator{WithdrawalCredentials: creds}
-	require.Equal(t, true, helpers.HasETH1WithdrawalCredential(v))
-	// No Withdrawal cred
-	v = &ethpb.Validator{}
-	require.Equal(t, false, helpers.HasETH1WithdrawalCredential(v))
-}
-
-func TestHasCompoundingWithdrawalCredential(t *testing.T) {
-	tests := []struct {
-		name      string
-		validator *ethpb.Validator
-		want      bool
-	}{
-		{"Has compounding withdrawal credential",
-			&ethpb.Validator{WithdrawalCredentials: bytesutil.PadTo([]byte{params.BeaconConfig().CompoundingWithdrawalPrefixByte}, 32)},
-			true},
-		{"Does not have compounding withdrawal credential",
-			&ethpb.Validator{WithdrawalCredentials: bytesutil.PadTo([]byte{0x00}, 32)},
-			false},
-		{"Handles nil case", nil, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, helpers.HasCompoundingWithdrawalCredential(tt.validator))
-		})
-	}
-}
-
-func TestHasExecutionWithdrawalCredentials(t *testing.T) {
-	tests := []struct {
-		name      string
-		validator *ethpb.Validator
-		want      bool
-	}{
-		{"Has compounding withdrawal credential",
-			&ethpb.Validator{WithdrawalCredentials: bytesutil.PadTo([]byte{params.BeaconConfig().CompoundingWithdrawalPrefixByte}, 32)},
-			true},
-		{"Has eth1 withdrawal credential",
-			&ethpb.Validator{WithdrawalCredentials: bytesutil.PadTo([]byte{params.BeaconConfig().ETH1AddressWithdrawalPrefixByte}, 32)},
-			true},
-		{"Does not have compounding withdrawal credential or eth1 withdrawal credential",
-			&ethpb.Validator{WithdrawalCredentials: bytesutil.PadTo([]byte{0x00}, 32)},
-			false},
-		{"Handles nil case", nil, false},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, helpers.HasExecutionWithdrawalCredentials(tt.validator))
-		})
-	}
-}
-
 func TestIsFullyWithdrawableValidator(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -1283,37 +1226,6 @@ func TestIsSameWithdrawalCredentials(t *testing.T) {
 			assert.Equal(t, tt.want, helpers.IsSameWithdrawalCredentials(tt.a, tt.b))
 		})
 	}
-}
-
-func TestValidatorMaxEffectiveBalance(t *testing.T) {
-	tests := []struct {
-		name      string
-		validator *ethpb.Validator
-		want      uint64
-	}{
-		{
-			name:      "Compounding withdrawal credential",
-			validator: &ethpb.Validator{WithdrawalCredentials: []byte{params.BeaconConfig().CompoundingWithdrawalPrefixByte, 0xCC}},
-			want:      params.BeaconConfig().MaxEffectiveBalanceAlpaca,
-		},
-		{
-			name:      "Vanilla credentials",
-			validator: &ethpb.Validator{WithdrawalCredentials: []byte{params.BeaconConfig().ETH1AddressWithdrawalPrefixByte, 0xCC}},
-			want:      params.BeaconConfig().MinActivationBalance,
-		},
-		{
-			"Handles nil case",
-			nil,
-			params.BeaconConfig().MinActivationBalance,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, helpers.ValidatorMaxEffectiveBalance(tt.validator))
-		})
-	}
-	// Sanity check that MinActivationBalance equals (pre-electra) MaxEffectiveBalance
-	assert.Equal(t, params.BeaconConfig().MinActivationBalance, params.BeaconConfig().MaxEffectiveBalance)
 }
 
 func TestGetWithdrawableEpoch(t *testing.T) {

--- a/beacon-chain/rpc/over/BUILD.bazel
+++ b/beacon-chain/rpc/over/BUILD.bazel
@@ -4,8 +4,8 @@ go_library(
     name = "go_default_library",
     srcs = [
         "handlers.go",
-        "handlers_withdrawal.go",
         "handlers_deposit.go",
+        "handlers_withdrawal.go",
         "server.go",
     ],
     importpath = "github.com/prysmaticlabs/prysm/v5/beacon-chain/rpc/over",
@@ -36,9 +36,9 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "handlers_deposit_test.go",
         "handlers_test.go",
         "handlers_withdrawal_test.go",
-        "handlers_deposit_test.go",
     ],
     embed = [":go_default_library"],
     deps = [

--- a/beacon-chain/state/state-native/getters_validator.go
+++ b/beacon-chain/state/state-native/getters_validator.go
@@ -2,7 +2,6 @@ package state_native
 
 import (
 	"github.com/pkg/errors"
-	"github.com/prysmaticlabs/prysm/v5/beacon-chain/core/helpers"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v5/config/features"
 	fieldparams "github.com/prysmaticlabs/prysm/v5/config/fieldparams"
@@ -451,8 +450,7 @@ func (b *BeaconState) inactivityScoreAtIndex(idx primitives.ValidatorIndex) (uin
 // Spec definition:
 //
 //	def get_active_balance(state: BeaconState, validator_index: ValidatorIndex) -> Gwei:
-//	    max_effective_balance = get_validator_max_effective_balance(state.validators[validator_index])
-//	    return min(state.balances[validator_index], max_effective_balance)
+//		return min(state.balances[validator_index], MAX_EFFECTIVE_BALANCE_ELECTRA)
 func (b *BeaconState) ActiveBalanceAtIndex(i primitives.ValidatorIndex) (uint64, error) {
 	if b.version < version.Electra {
 		return 0, errNotSupported("ActiveBalanceAtIndex", b.version)
@@ -461,17 +459,12 @@ func (b *BeaconState) ActiveBalanceAtIndex(i primitives.ValidatorIndex) (uint64,
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	v, err := b.validatorAtIndex(i)
-	if err != nil {
-		return 0, err
-	}
-
 	bal, err := b.balanceAtIndex(i)
 	if err != nil {
 		return 0, err
 	}
 
-	return min(bal, helpers.ValidatorMaxEffectiveBalance(v)), nil
+	return min(bal, params.BeaconConfig().MaxEffectiveBalanceAlpaca), nil
 }
 
 // PendingBalanceToWithdraw returns the sum of all pending withdrawals for the given validator.


### PR DESCRIPTION
Disables validator prefixes according to spec.
Every validator would be able to perform as if they were a compounding validator regardless of their prefix.
Note that bls_to_execution_change still exists, so validators with prefix 0x00 will still be able to change their credentials.