### PR TITLE
Stop rebuilding deposit trie in post-alpaca

### DIFF
--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_deposits.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_deposits.go
@@ -94,6 +94,14 @@ func (vs *Server) deposits(
 		return nil, err
 	}
 
+	// In the post-alpaca (Electra) phase, this function will usually return an empty list,
+	// as the legacy deposit process is deprecated.
+	// NOTE: During the transition period, the legacy deposit process
+	// may still be active and managed. This function handles that scenario.
+	if !isLegacyDepositProcessPeriod(beaconState, canonicalEth1Data) {
+		return []*ethpb.Deposit{}, nil
+	}
+
 	_, genesisEth1Block := vs.Eth1InfoFetcher.GenesisExecutionChainInfo()
 	if genesisEth1Block.Cmp(canonicalEth1DataHeight) == 0 {
 		return []*ethpb.Deposit{}, nil
@@ -276,4 +284,22 @@ func shouldRebuildTrie(totalDepCount, unFinalizedDeps uint64) bool {
 	// the deposit trie, the value of log(x) + k is fixed at 32.
 	unFinalizedCompute := unFinalizedDeps * params.BeaconConfig().DepositContractTreeDepth
 	return unFinalizedCompute > totalDepCount
+}
+
+// isLegacyDepositProcessPeriod determines if the current state should use the legacy deposit process.
+func isLegacyDepositProcessPeriod(beaconState state.BeaconState, canonicalEth1Data *ethpb.Eth1Data) bool {
+	// Before the Alpaca upgrade, always use the legacy deposit process.
+	if beaconState.Version() < version.Alpaca {
+		return true
+	}
+
+	// Handle the transition period between the legacy and the new deposit process.
+	requestsStartIndex, err := beaconState.DepositRequestsStartIndex()
+	if err != nil {
+		// If we can't get the deposit requests start index,
+		// we should default to the legacy deposit process.
+		return true
+	}
+	eth1DepositIndexLimit := math.Min(canonicalEth1Data.DepositCount, requestsStartIndex)
+	return beaconState.Eth1DepositIndex() < eth1DepositIndexLimit
 }

--- a/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_deposits_test.go
+++ b/beacon-chain/rpc/prysm/v1alpha1/validator/proposer_deposits_test.go
@@ -2,12 +2,14 @@ package validator
 
 import (
 	"context"
+	"math"
 	"math/big"
 	"testing"
 
 	mock "github.com/prysmaticlabs/prysm/v5/beacon-chain/blockchain/testing"
 	"github.com/prysmaticlabs/prysm/v5/beacon-chain/cache/depositsnapshot"
 	mockExecution "github.com/prysmaticlabs/prysm/v5/beacon-chain/execution/testing"
+	"github.com/prysmaticlabs/prysm/v5/beacon-chain/state"
 	state_native "github.com/prysmaticlabs/prysm/v5/beacon-chain/state/state-native"
 	"github.com/prysmaticlabs/prysm/v5/config/params"
 	"github.com/prysmaticlabs/prysm/v5/container/trie"
@@ -211,4 +213,86 @@ func TestProposer_PendingDeposits_Electra(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 0, len(deposits), "Received unexpected number of pending deposits")
 
+}
+
+func TestIsLegacyDepositProcessPeriod(t *testing.T) {
+	tests := []struct {
+		name              string
+		state             state.BeaconState
+		canonicalEth1Data *ethpb.Eth1Data
+		want              bool
+	}{
+		{
+			name: "pre-alpaca",
+			state: func() state.BeaconState {
+				st, err := state_native.InitializeFromProtoDeneb(&ethpb.BeaconStateDeneb{
+					Eth1Data: &ethpb.Eth1Data{
+						BlockHash:    []byte("0x0"),
+						DepositRoot:  make([]byte, 32),
+						DepositCount: 5,
+					},
+					Eth1DepositIndex: 1,
+				})
+				require.NoError(t, err)
+				return st
+			}(),
+			canonicalEth1Data: &ethpb.Eth1Data{
+				BlockHash:    []byte("0x0"),
+				DepositRoot:  make([]byte, 32),
+				DepositCount: 5,
+			},
+			want: true,
+		},
+		{
+			name: "post-alpaca, pending deposits from pre-alpaca",
+			state: func() state.BeaconState {
+				st, err := state_native.InitializeFromProtoElectra(&ethpb.BeaconStateElectra{
+					Eth1Data: &ethpb.Eth1Data{
+						BlockHash:    []byte("0x0"),
+						DepositRoot:  make([]byte, 32),
+						DepositCount: 5,
+					},
+					DepositRequestsStartIndex: math.MaxUint64,
+					Eth1DepositIndex:          1,
+				})
+				require.NoError(t, err)
+				return st
+			}(),
+			canonicalEth1Data: &ethpb.Eth1Data{
+				BlockHash:    []byte("0x0"),
+				DepositRoot:  make([]byte, 32),
+				DepositCount: 5,
+			},
+			want: true,
+		},
+		{
+			name: "post-alpaca, no pending deposits from pre-alpaca",
+			state: func() state.BeaconState {
+				st, err := state_native.InitializeFromProtoElectra(&ethpb.BeaconStateElectra{
+					Eth1Data: &ethpb.Eth1Data{
+						BlockHash:    []byte("0x0"),
+						DepositRoot:  make([]byte, 32),
+						DepositCount: 5,
+					},
+					DepositRequestsStartIndex: 1,
+					Eth1DepositIndex:          5,
+				})
+				require.NoError(t, err)
+				return st
+			}(),
+			canonicalEth1Data: &ethpb.Eth1Data{
+				BlockHash:    []byte("0x0"),
+				DepositRoot:  make([]byte, 32),
+				DepositCount: 5,
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isLegacyDepositProcessPeriod(tt.state, tt.canonicalEth1Data); got != tt.want {
+				t.Errorf("isLegacyDepositProcessPeriod() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
```
"Too many unfinalized deposits, building a deposit trie from scratch." prefix="rpc/validator" totalDepositCount=589680 unfinalizedDeposits=589680
```

<img width="1044" alt="image" src="https://github.com/user-attachments/assets/f65f7f6c-5ebd-4bf1-9ae6-47a65b6b775d">


We found that all deposits since the Alpaca fork are considered "non-finalized" in the context of the deposit snapshot (see [EIP-4881](https://eips.ethereum.org/EIPS/eip-4881)). This caused high CPU and memory usage when a validator node builds a block.
This PR adds a simple branch for the post-Alpaca phase. With EIP-6110 applied, `packDepositsAndAttestations` will always return an empty list of deposits in the post-Alpaca era. During the transition period, the legacy deposit process may still be active, and `isLegacyDepositProcessPeriod` handles this case. (`TestIsLegacyDepositProcessPeriod` describes the case.)

**Other notes for review**

- A devnet test should be arranged for this.
- The deposit cache module was not removed because it is still required for constructing Eth1 votes.
