### PR TITLE
Apply eip7549 to slashing pool

### DIFF
--- a/beacon-chain/operations/slashings/BUILD.bazel
+++ b/beacon-chain/operations/slashings/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//container/slice:go_default_library",
         "//monitoring/tracing/trace:go_default_library",
         "//proto/prysm/v1alpha1:go_default_library",
+        "//runtime/version:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promauto:go_default_library",

--- a/beacon-chain/operations/slashings/service.go
+++ b/beacon-chain/operations/slashings/service.go
@@ -43,6 +43,11 @@ func (p *Pool) PendingAttesterSlashings(ctx context.Context, state state.ReadOnl
 
 	// Allocate pending slice with a capacity of maxAttesterSlashings or len(p.pendingAttesterSlashing)) depending on the request.
 	maxSlashings := params.BeaconConfig().MaxAttesterSlashings
+
+	// EIP-7549: Beginning from Electra, the max attester slashings is reduced to 1.
+	if state.Version() >= version.Electra {
+		maxSlashings = params.BeaconConfig().MaxAttesterSlashingsElectra
+	}
 	if noLimit {
 		maxSlashings = uint64(len(p.pendingAttesterSlashing))
 	}

--- a/beacon-chain/operations/slashings/service.go
+++ b/beacon-chain/operations/slashings/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prysmaticlabs/prysm/v5/container/slice"
 	"github.com/prysmaticlabs/prysm/v5/monitoring/tracing/trace"
 	ethpb "github.com/prysmaticlabs/prysm/v5/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v5/runtime/version"
 	"github.com/trailofbits/go-mutexasserts"
 )
 
@@ -42,12 +43,14 @@ func (p *Pool) PendingAttesterSlashings(ctx context.Context, state state.ReadOnl
 	included := make(map[primitives.ValidatorIndex]bool)
 
 	// Allocate pending slice with a capacity of maxAttesterSlashings or len(p.pendingAttesterSlashing)) depending on the request.
-	maxSlashings := params.BeaconConfig().MaxAttesterSlashings
-
-	// EIP-7549: Beginning from Electra, the max attester slashings is reduced to 1.
-	if state.Version() >= version.Electra {
-		maxSlashings = params.BeaconConfig().MaxAttesterSlashingsElectra
+	var maxSlashings uint64
+	if state.Version() >= version.Alpaca {
+		// EIP-7549: Beginning from Electra, the max attester slashings is reduced to 1.
+		maxSlashings = params.BeaconConfig().MaxAttesterSlashingsAlpaca
+	} else {
+		maxSlashings = params.BeaconConfig().MaxAttesterSlashings
 	}
+
 	if noLimit {
 		maxSlashings = uint64(len(p.pendingAttesterSlashing))
 	}

--- a/beacon-chain/operations/slashings/service_attester_test.go
+++ b/beacon-chain/operations/slashings/service_attester_test.go
@@ -520,7 +520,7 @@ func TestPool_PendingAttesterSlashings(t *testing.T) {
 	}
 }
 
-func TestPool_PendingAttesterSlashings_AfterElectra(t *testing.T) {
+func TestPool_PendingAttesterSlashings_AfterAlpaca(t *testing.T) {
 	type fields struct {
 		pending []*PendingAttesterSlashing
 		all     bool

--- a/beacon-chain/operations/slashings/service_attester_test.go
+++ b/beacon-chain/operations/slashings/service_attester_test.go
@@ -520,6 +520,70 @@ func TestPool_PendingAttesterSlashings(t *testing.T) {
 	}
 }
 
+func TestPool_PendingAttesterSlashings_AfterElectra(t *testing.T) {
+	type fields struct {
+		pending []*PendingAttesterSlashing
+		all     bool
+	}
+	params.SetupTestConfigCleanup(t)
+	beaconState, privKeys := util.DeterministicGenesisStateElectra(t, 64)
+
+	pendingSlashings := make([]*PendingAttesterSlashing, 20)
+	slashings := make([]ethpb.AttSlashing, 20)
+	for i := 0; i < len(pendingSlashings); i++ {
+		sl, err := util.GenerateAttesterSlashingForValidator(beaconState, privKeys[i], primitives.ValidatorIndex(i))
+		require.NoError(t, err)
+		pendingSlashings[i] = &PendingAttesterSlashing{
+			attesterSlashing: sl,
+			validatorToSlash: primitives.ValidatorIndex(i),
+		}
+		slashings[i] = sl
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   []ethpb.AttSlashing
+	}{
+		{
+			name: "Empty list",
+			fields: fields{
+				pending: []*PendingAttesterSlashing{},
+			},
+			want: []ethpb.AttSlashing{},
+		},
+		{
+			name: "All pending",
+			fields: fields{
+				pending: pendingSlashings,
+				all:     true,
+			},
+			want: slashings,
+		},
+		{
+			name: "All eligible",
+			fields: fields{
+				pending: pendingSlashings,
+			},
+			want: slashings[0:1],
+		},
+		{
+			name: "Multiple indices",
+			fields: fields{
+				pending: pendingSlashings[3:6],
+			},
+			want: slashings[3:4],
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Pool{
+				pendingAttesterSlashing: tt.fields.pending,
+			}
+			assert.DeepEqual(t, tt.want, p.PendingAttesterSlashings(context.Background(), beaconState, tt.fields.all))
+		})
+	}
+}
+
 func TestPool_PendingAttesterSlashings_Slashed(t *testing.T) {
 	type fields struct {
 		pending []*PendingAttesterSlashing


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, check out our contribution guide.
2. Please file an associated tracking issue if this pull request is non-trivial and requires context for our team to understand. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The maximum number of attester slashings per block was incorrectly handled following the Electra version upgrade.
According to [EIP-7549](https://eips.ethereum.org/EIPS/eip-7549#max_attester_slashings-value), the maximum allowable attester slashings has been reduced from 2 to 1 in Electra. This PR updates the implementation and test cases to follow the rule when producing a new block.
