### PR TITLE
Fix hard-coded version name in GetVersion API

### DIFF
--- a/beacon-chain/rpc/eth/node/handlers.go
+++ b/beacon-chain/rpc/eth/node/handlers.go
@@ -97,7 +97,7 @@ func (*Server) GetVersion(w http.ResponseWriter, r *http.Request) {
 	_, span := trace.StartSpan(r.Context(), "node.GetVersion")
 	defer span.End()
 
-	v := fmt.Sprintf("Prysm/%s (%s %s)", version.SemanticVersion(), runtime.GOOS, runtime.GOARCH)
+	v := fmt.Sprintf("Chronos/%s (%s %s)", version.SemanticVersion(), runtime.GOOS, runtime.GOARCH)
 	resp := &structs.GetVersionResponse{
 		Data: &structs.Version{
 			Version: v,


### PR DESCRIPTION
`GET /eth/v1/node/version` will return hard coded value, so changed default string.