### PR TITLE
Fix default prefix for withdrawal credentials

### DIFF
--- a/validator/rpc/handlers_accounts.go
+++ b/validator/rpc/handlers_accounts.go
@@ -545,8 +545,8 @@ func createDepositData(
 }
 
 // eth1WithdrawalCredential wraps eth1 address(20 bytes) into
-// eth1 withdrawal credential(32 bytes).
+// valid withdrawal credential(32 bytes).
 func eth1WithdrawalCredential(eth1WithdrawalAddress []byte) []byte {
-	prefix := params.BeaconConfig().CompoundingWithdrawalPrefixByte
+	prefix := byte(0)
 	return append(append([]byte{prefix}, params.BeaconConfig().ZeroHash[1:12]...), eth1WithdrawalAddress[:20]...)[:32]
 }

--- a/validator/rpc/handlers_accounts_test.go
+++ b/validator/rpc/handlers_accounts_test.go
@@ -661,7 +661,7 @@ func Test_eth1WithdrawalCredential(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 20, len(eth1Address))
 	wc := eth1WithdrawalCredential(eth1Address)
-	require.Equal(t, "0x020000000000000000000000a83114a443da1cecefc50368531cace9f37fcccb", hexutil.Encode(wc))
+	require.Equal(t, "0x000000000000000000000000a83114a443da1cecefc50368531cace9f37fcccb", hexutil.Encode(wc))
 	require.Equal(t, 32, len(wc))
 }
 


### PR DESCRIPTION
As prefixes of withdrawal credentials have no meaning at all, fix the default prefix into `0x00` for the sake of unity with [staking-deposit-cli](https://github.com/overprotocol/staking-deposit-cli).

NOTE: This will never affect the consensus, since it is for new validators.