### PR TITLE
Disable normal build ends with `_exp`

### DIFF
--- a/.github/workflows/tag-build.yml
+++ b/.github/workflows/tag-build.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*_*" # Format: v<major>.<minor>.<patch>[_<stable|beta|dev>]
+      - "!v*_exp" # Exclude tags ending with _exp
 
 permissions:
   contents: write


### PR DESCRIPTION
Disable triggering build action if a tag ends with `_exp`