### PR TITLE
Fix `buildPendingDepositEstimations`: large amount of deposit could lead an estimation error

### DIFF
--- a/beacon-chain/rpc/over/handlers_deposit.go
+++ b/beacon-chain/rpc/over/handlers_deposit.go
@@ -278,10 +278,10 @@ func buildPendingDepositEstimations(st state.BeaconState, pubkeyFilter []byte, i
 		// Premise: finalizedSlot will always be incremented by 32 slots(= 1 epoch).
 		for pd.Slot > finalizedSlot {
 			currentEpoch += 1
-
-			availableForProcessing = balanceChurnLimit
 			finalizedSlot += params.BeaconConfig().SlotsPerEpoch
 
+			// Reset per-epoch tracking variables
+			availableForProcessing = balanceChurnLimit
 			processedAmount = uint64(0)
 			depositCount = uint64(0)
 		}
@@ -289,10 +289,10 @@ func buildPendingDepositEstimations(st state.BeaconState, pubkeyFilter []byte, i
 		// Move to next epoch if max pending deposits per epoch is reached.
 		if depositCount >= params.BeaconConfig().MaxPendingDepositsPerEpoch {
 			currentEpoch += 1
-
-			availableForProcessing = balanceChurnLimit
 			finalizedSlot += params.BeaconConfig().SlotsPerEpoch
 
+			// Reset per-epoch tracking variables
+			availableForProcessing = balanceChurnLimit
 			processedAmount = uint64(0)
 			depositCount = uint64(0)
 		}
@@ -315,9 +315,9 @@ func buildPendingDepositEstimations(st state.BeaconState, pubkeyFilter []byte, i
 			// If churn limit is reached, move to the next epoch.
 			if isChurnLimitReached {
 				currentEpoch += 1
-
 				finalizedSlot += params.BeaconConfig().SlotsPerEpoch
 
+				// Reset per-epoch tracking variables
 				depBalToConsume = availableForProcessing - primitives.Gwei(processedAmount)
 				// deposit_balance_to_consume only matters when the churn limit is reached.
 				availableForProcessing = depBalToConsume + balanceChurnLimit

--- a/beacon-chain/rpc/over/handlers_deposit.go
+++ b/beacon-chain/rpc/over/handlers_deposit.go
@@ -311,9 +311,8 @@ func buildPendingDepositEstimations(st state.BeaconState, pubkeyFilter []byte, i
 		}
 
 		if !isValidatorWithdrawn && !isValidatorExited {
-			isChurnLimitReached := primitives.Gwei(processedAmount+pd.Amount) > availableForProcessing
-			// If churn limit is reached, move to the next epoch.
-			if isChurnLimitReached {
+			// If churn limit is reached, move to the next epoch while it can be consumed.
+			for primitives.Gwei(processedAmount+pd.Amount) > availableForProcessing {
 				currentEpoch += 1
 				finalizedSlot += params.BeaconConfig().SlotsPerEpoch
 

--- a/beacon-chain/rpc/over/handlers_deposit_test.go
+++ b/beacon-chain/rpc/over/handlers_deposit_test.go
@@ -230,8 +230,8 @@ func TestGetDepositEstimation(t *testing.T) {
 						Data: &structs.PendingDepositEstimation{
 							Amount:                  params.BeaconConfig().MaxEffectiveBalanceAlpaca,
 							Slot:                    321,
-							ExpectedEpoch:           14,
-							ExpectedActivationEpoch: 22,
+							ExpectedEpoch:           16,
+							ExpectedActivationEpoch: 24,
 						},
 					},
 				},


### PR DESCRIPTION
In the current implementation, logic regarding to `isChurnLimitReached` is incorrect as it only increments `currentEpoch` by one.