### PR TITLE
Fix eventstream electra atts (#14655)

### DIFF
--- a/beacon-chain/rpc/eth/events/events.go
+++ b/beacon-chain/rpc/eth/events/events.go
@@ -416,14 +416,20 @@ func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, topi
 			return jsonMarshalReader(eventName, att)
 		}, nil
 	case *operation.UnAggregatedAttReceivedData:
-		att, ok := v.Attestation.(*eth.Attestation)
-		if !ok {
+		switch att := v.Attestation.(type) {
+		case *eth.Attestation:
+			return func() io.Reader {
+				att := structs.AttFromConsensus(att)
+				return jsonMarshalReader(eventName, att)
+			}, nil
+		case *eth.AttestationElectra:
+			return func() io.Reader {
+				att := structs.AttElectraFromConsensus(att)
+				return jsonMarshalReader(eventName, att)
+			}, nil
+		default:
 			return nil, errors.Wrapf(errUnhandledEventData, "Unexpected type %T for the .Attestation field of UnAggregatedAttReceivedData", v.Attestation)
 		}
-		return func() io.Reader {
-			att := structs.AttFromConsensus(att)
-			return jsonMarshalReader(eventName, att)
-		}, nil
 	case *operation.ExitReceivedData:
 		return func() io.Reader {
 			return jsonMarshalReader(eventName, structs.SignedExitFromConsensus(v.Exit))
@@ -440,13 +446,18 @@ func (s *Server) lazyReaderForEvent(ctx context.Context, event *feed.Event, topi
 			})
 		}, nil
 	case *operation.AttesterSlashingReceivedData:
-		slashing, ok := v.AttesterSlashing.(*eth.AttesterSlashing)
-		if !ok {
+		switch slashing := v.AttesterSlashing.(type) {
+		case *eth.AttesterSlashing:
+			return func() io.Reader {
+				return jsonMarshalReader(eventName, structs.AttesterSlashingFromConsensus(slashing))
+			}, nil
+		case *eth.AttesterSlashingElectra:
+			return func() io.Reader {
+				return jsonMarshalReader(eventName, structs.AttesterSlashingElectraFromConsensus(slashing))
+			}, nil
+		default:
 			return nil, errors.Wrapf(errUnhandledEventData, "Unexpected type %T for the .AttesterSlashing field of AttesterSlashingReceivedData", v.AttesterSlashing)
 		}
-		return func() io.Reader {
-			return jsonMarshalReader(eventName, structs.AttesterSlashingFromConsensus(slashing))
-		}, nil
 	case *operation.ProposerSlashingReceivedData:
 		return func() io.Reader {
 			return jsonMarshalReader(eventName, structs.ProposerSlashingFromConsensus(v.ProposerSlashing))


### PR DESCRIPTION
This PR addresses an issue with `/eth/v1/events` endpoint: `Attestation` event doesn't emit because of EIP-7549. Applied https://github.com/prysmaticlabs/prysm/commit/25eae3acda45c0e6f250575b83da8c7fa9b3c0a9